### PR TITLE
admin access works

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -27,6 +27,7 @@ tutee_cs_scholar = {:sid => 123456789, :first_name => "Peter", :last_name => "Gr
 tutee_not_cs_scholar = {:sid => 123456789, :first_name => "Naruto", :last_name => "Uzumaki", :email => "bobs@berkeley.edu", :birthdate => Time.now, :privilege => 'No', :gender => 'male',
                         :ethnicity => 'Asian', :dsp => 'Yes', :transfer => 'Yes', :year => '4+', :pronoun => 'he/his', :major => 'EECS'}
 
+Admin.create(:id => 1, :password => "admin", :current_semester => "Spring2019", :statistics_semester => "Spring2019")
 tutors.each do |tutor|
   Tutor.create!(tutor)
 end


### PR DESCRIPTION
Seed Admin into Database

Purpose

The purpose of this Pull Request is to be able to seed admin into the database manually.

User Story

- As an admin 
- When I login
- Then I should be able to see the admin dashboard

Changes

- db/seeds.rb
    - Manually created an admin instance

Screenshots
<img width="1254" alt="Screen Shot 2019-11-17 at 5 01 01 PM" src="https://user-images.githubusercontent.com/46780937/69017433-df39c300-095b-11ea-9011-1d687d5518f0.png">


Pivotal Tracker Links
https://www.pivotaltracker.com/story/show/169802228