### PR TITLE
Remove Announcements From Student Dashboard

### DIFF
--- a/app/views/tutees/show.html.haml
+++ b/app/views/tutees/show.html.haml
@@ -55,14 +55,6 @@
           %span.float-right
             %i.glyphicon.glyphicon-pushpin
 
-  / Area Chart Example
-  .card.mb-3
-    .card-header
-      %span.glyphicon.glyphicon-volume-up Week Announcement(s)
-    .card-body
-      %p This space is reserved for weekly messages!
-    .card-footer.small.text-muted Updated yesterday at 11:59 PM
-
   / DataTables Example
   .card.mb-3#request
     .card-header


### PR DESCRIPTION
# Remove Announcements From Student Dashboard

## Purpose

Student dashboard does not need announcements, so the UI card has been removed

## Changes

- app/views/tutees/**show.html.haml**
    - Removed announcements UI element

## Screenshots

## Pivotal Tracker Links
