### PR TITLE
Add UPPERDIV and OTHER as class options

### DIFF
--- a/app/controllers/tutors/registrations_controller.rb
+++ b/app/controllers/tutors/registrations_controller.rb
@@ -52,7 +52,7 @@ class Tutors::RegistrationsController < Devise::RegistrationsController
     BerkeleyClass.all_classes.each do |current_class|
       params[:classes][current_class] = params[:classes].has_key?(current_class) #true hash string => all hash boolean
     end
-   params.require(:classes).permit(:CS61A, :CS61B, :CS61C, :CS70, :EE16A, :EE16B, :CS88, :CS10, :DATA8) #maybe store this list as a constant
+   params.require(:classes).permit(:CS61A, :CS61B, :CS61C, :CS70, :EE16A, :EE16B, :CS88, :CS10, :DATA8, :UPPERDIV, :OTHER) #maybe store this list as a constant
   end
 
   # GET /resource/edit

--- a/app/controllers/tutors_controller.rb
+++ b/app/controllers/tutors_controller.rb
@@ -155,7 +155,7 @@ class TutorsController < ApplicationController
       BerkeleyClass.all_classes.each do |current_class|
         params[:classes][current_class] = params[:classes].has_key?(current_class) #true hash string => all hash boolean
       end
-     params.require(:classes).permit(:CS61A, :CS61B, :CS61C, :CS70, :EE16A, :EE16B, :CS88, :CS10, :DATA8) #maybe store this list as a constant
+     params.require(:classes).permit(:CS61A, :CS61B, :CS61C, :CS70, :EE16A, :EE16B, :CS88, :CS10, :DATA8, :UPPERDIV, :OTHER) #maybe store this list as a constant
     end
 
 

--- a/coverage/index.html
+++ b/coverage/index.html
@@ -14,7 +14,7 @@
       <img src="./assets/0.10.2/loading.gif" alt="loading"/>
     </div>
     <div id="wrapper" style="display:none;">
-      <div class="timestamp">Generated <abbr class="timeago" title="2019-12-13T16:10:45-08:00">2019-12-13T16:10:45-08:00</abbr></div>
+      <div class="timestamp">Generated <abbr class="timeago" title="2019-12-13T17:35:53-08:00">2019-12-13T17:35:53-08:00</abbr></div>
       <ul class="group_tabs"></ul>
 
       <div id="content">
@@ -25,7 +25,7 @@
      covered at
      <span class="covered_strength">
        <span class="green">
-         6.06
+         6.12
        </span>
     </span> hits/line)
   </h2>
@@ -51,7 +51,7 @@
     <tbody>
       
       <tr>
-        <td class="strong"><a href="#26463c231c580ceb270824e18bbe5ff01911c6ac" class="src_link" title="app/controllers/admins_controller.rb">app/controllers/admins_controller.rb</a></td>
+        <td class="strong"><a href="#510b765e2df081cf54826c9cf6a4c5355f04c390" class="src_link" title="app/controllers/admins_controller.rb">app/controllers/admins_controller.rb</a></td>
         <td class="green strong">94.4 %</td>
         <td>210</td>
         <td>125</td>
@@ -61,7 +61,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#deb1544369d2b944365327c02b6185c2c171cc09" class="src_link" title="app/controllers/application_controller.rb">app/controllers/application_controller.rb</a></td>
+        <td class="strong"><a href="#348beacf8f7812cef945c615b627da2290d063c9" class="src_link" title="app/controllers/application_controller.rb">app/controllers/application_controller.rb</a></td>
         <td class="green strong">97.62 %</td>
         <td>69</td>
         <td>42</td>
@@ -71,7 +71,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#b5fb3d324d2acbdaa2bc00feaf2285278e5aa25f" class="src_link" title="app/controllers/concerns/friendlyable.rb">app/controllers/concerns/friendlyable.rb</a></td>
+        <td class="strong"><a href="#3d40176ccfe2c3a853fc03d671a10d1634b48db2" class="src_link" title="app/controllers/concerns/friendlyable.rb">app/controllers/concerns/friendlyable.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>16</td>
         <td>12</td>
@@ -81,7 +81,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#2dc131ec131b9be95156a4bc77cbf698519fe74f" class="src_link" title="app/controllers/evaluations_controller.rb">app/controllers/evaluations_controller.rb</a></td>
+        <td class="strong"><a href="#57dd48fbe1fdafeb41d65c6ceb67f360340b5962" class="src_link" title="app/controllers/evaluations_controller.rb">app/controllers/evaluations_controller.rb</a></td>
         <td class="green strong">91.89 %</td>
         <td>65</td>
         <td>37</td>
@@ -91,7 +91,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#ac28a37c753dec5f383ed99f7c7084fa7c6c6571" class="src_link" title="app/controllers/meetings_controller.rb">app/controllers/meetings_controller.rb</a></td>
+        <td class="strong"><a href="#2106888026f42fd22c735d957f561e0af1c320f4" class="src_link" title="app/controllers/meetings_controller.rb">app/controllers/meetings_controller.rb</a></td>
         <td class="yellow strong">89.74 %</td>
         <td>62</td>
         <td>39</td>
@@ -101,7 +101,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#932021a8f8c5ed62e3f0d175ddf50739ab3e035d" class="src_link" title="app/controllers/requests_controller.rb">app/controllers/requests_controller.rb</a></td>
+        <td class="strong"><a href="#72de3d9e237bb4471a855f9c8201c651be77820a" class="src_link" title="app/controllers/requests_controller.rb">app/controllers/requests_controller.rb</a></td>
         <td class="red strong">50.0 %</td>
         <td>123</td>
         <td>78</td>
@@ -111,7 +111,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#6b20b2772ab1342c1afcc3a0a476461fabbfc224" class="src_link" title="app/controllers/tutees/registrations_controller.rb">app/controllers/tutees/registrations_controller.rb</a></td>
+        <td class="strong"><a href="#e64874275626fcc3ae8959a26f21a3468340e4ae" class="src_link" title="app/controllers/tutees/registrations_controller.rb">app/controllers/tutees/registrations_controller.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>85</td>
         <td>19</td>
@@ -121,7 +121,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#524a6d064aff187c5c208a80e218684f4bd44de7" class="src_link" title="app/controllers/tutees_controller.rb">app/controllers/tutees_controller.rb</a></td>
+        <td class="strong"><a href="#ad677769a193cf4943352f9262ea6dac4d146740" class="src_link" title="app/controllers/tutees_controller.rb">app/controllers/tutees_controller.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>42</td>
         <td>18</td>
@@ -131,7 +131,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#66ec2ac933ea6d38096d79e24af1654ce81c8ec5" class="src_link" title="app/controllers/tutors/registrations_controller.rb">app/controllers/tutors/registrations_controller.rb</a></td>
+        <td class="strong"><a href="#d9c28fab816d4b19ddacefad3fd3e700e02500e1" class="src_link" title="app/controllers/tutors/registrations_controller.rb">app/controllers/tutors/registrations_controller.rb</a></td>
         <td class="yellow strong">84.85 %</td>
         <td>108</td>
         <td>33</td>
@@ -141,7 +141,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#3c314adbf60036b9b6074fb2b5d3353691f4ea61" class="src_link" title="app/controllers/tutors_controller.rb">app/controllers/tutors_controller.rb</a></td>
+        <td class="strong"><a href="#60a689a886f70e3641bfa2e100503f5046712f66" class="src_link" title="app/controllers/tutors_controller.rb">app/controllers/tutors_controller.rb</a></td>
         <td class="red strong">76.14 %</td>
         <td>162</td>
         <td>88</td>
@@ -151,7 +151,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#f06df8ccd52345012d0ad9b304349601da1e107e" class="src_link" title="app/controllers/welcome_controller.rb">app/controllers/welcome_controller.rb</a></td>
+        <td class="strong"><a href="#3d734bc430266f3cf802e2b243612cf78677c6e5" class="src_link" title="app/controllers/welcome_controller.rb">app/controllers/welcome_controller.rb</a></td>
         <td class="red strong">31.25 %</td>
         <td>26</td>
         <td>16</td>
@@ -161,7 +161,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#5975818c13bc92d2fb951b5f1f5cc20cfd8502c9" class="src_link" title="app/helpers/admins_helper.rb">app/helpers/admins_helper.rb</a></td>
+        <td class="strong"><a href="#941c942065a544ef86c6903f70711a8b43bd1e07" class="src_link" title="app/helpers/admins_helper.rb">app/helpers/admins_helper.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>2</td>
         <td>1</td>
@@ -171,7 +171,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#157ad42dedfca6052397934d1e6eebcae5b4dd40" class="src_link" title="app/helpers/application_helper.rb">app/helpers/application_helper.rb</a></td>
+        <td class="strong"><a href="#aeface27f87e8e7135585072dac682c128d014ae" class="src_link" title="app/helpers/application_helper.rb">app/helpers/application_helper.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>2</td>
         <td>1</td>
@@ -181,7 +181,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#0500870e5011744fa2d267fefc77606811ae5d3d" class="src_link" title="app/helpers/courses_helper.rb">app/helpers/courses_helper.rb</a></td>
+        <td class="strong"><a href="#01f96cf5d377b020d9d6503a655f54c297179749" class="src_link" title="app/helpers/courses_helper.rb">app/helpers/courses_helper.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>2</td>
         <td>1</td>
@@ -191,7 +191,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#ee840b6e77149293e2cbb55a91b7b554bc398886" class="src_link" title="app/helpers/evaluations_helper.rb">app/helpers/evaluations_helper.rb</a></td>
+        <td class="strong"><a href="#1ad11c446b3eed5f28adac5c36ca87826b2ac8ae" class="src_link" title="app/helpers/evaluations_helper.rb">app/helpers/evaluations_helper.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>2</td>
         <td>1</td>
@@ -201,7 +201,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#d61ada6e6be49a1e013bf9dc24b962f23be58a7d" class="src_link" title="app/helpers/requests_helper.rb">app/helpers/requests_helper.rb</a></td>
+        <td class="strong"><a href="#3bad6a647f680ea5e325d559327041e367c2e606" class="src_link" title="app/helpers/requests_helper.rb">app/helpers/requests_helper.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>2</td>
         <td>1</td>
@@ -211,7 +211,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#6c2235a720ab247c02c3f5d721ba7098867caed4" class="src_link" title="app/helpers/tutees_helper.rb">app/helpers/tutees_helper.rb</a></td>
+        <td class="strong"><a href="#6bbeb1a8170ef3e6279eb7e8e9ee79e86953d432" class="src_link" title="app/helpers/tutees_helper.rb">app/helpers/tutees_helper.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>2</td>
         <td>1</td>
@@ -221,7 +221,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#eada9445989d0eeb8bd69869dfa7582fe658d6f8" class="src_link" title="app/helpers/tutors_helper.rb">app/helpers/tutors_helper.rb</a></td>
+        <td class="strong"><a href="#1252bf43368e240153c365483e422901a8201ab8" class="src_link" title="app/helpers/tutors_helper.rb">app/helpers/tutors_helper.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>2</td>
         <td>1</td>
@@ -231,7 +231,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#a2c664dea4ddef56052d946c1476a954a8770a87" class="src_link" title="app/helpers/welcome_helper.rb">app/helpers/welcome_helper.rb</a></td>
+        <td class="strong"><a href="#eaa6ad621a726edee813fd1c8463a2f0e0a73ade" class="src_link" title="app/helpers/welcome_helper.rb">app/helpers/welcome_helper.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>2</td>
         <td>1</td>
@@ -241,7 +241,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#ed8eb0e3b50404db2f47123f1a5cfa375edb7c0c" class="src_link" title="app/models/admin.rb">app/models/admin.rb</a></td>
+        <td class="strong"><a href="#0419fecf8940bf36f80977d62bf4f5807a1062c4" class="src_link" title="app/models/admin.rb">app/models/admin.rb</a></td>
         <td class="green strong">90.48 %</td>
         <td>43</td>
         <td>21</td>
@@ -251,7 +251,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#23394b3f34a64f526639f3bf44d9b73f35adbdea" class="src_link" title="app/models/application_record.rb">app/models/application_record.rb</a></td>
+        <td class="strong"><a href="#3922d29b804811c40702288b75f3e6415da00413" class="src_link" title="app/models/application_record.rb">app/models/application_record.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>3</td>
         <td>2</td>
@@ -261,17 +261,17 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#6a19aefe4ad708ce3fb1f629b0687b1e78a14c61" class="src_link" title="app/models/berkeley_class.rb">app/models/berkeley_class.rb</a></td>
+        <td class="strong"><a href="#95ab858a67083526fabd9d80b077e16d3d000ddb" class="src_link" title="app/models/berkeley_class.rb">app/models/berkeley_class.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>21</td>
         <td>12</td>
         <td>12</td>
         <td>0</td>
-        <td>43.9</td>
+        <td>50.1</td>
       </tr>
       
       <tr>
-        <td class="strong"><a href="#c36bb0d35cb766151604bff00688dbba1e12b94d" class="src_link" title="app/models/course.rb">app/models/course.rb</a></td>
+        <td class="strong"><a href="#9247d3bf5a04545e69457bfd27d4c3b898b47014" class="src_link" title="app/models/course.rb">app/models/course.rb</a></td>
         <td class="green strong">95.65 %</td>
         <td>53</td>
         <td>23</td>
@@ -281,7 +281,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#a8dab1bd2236a88b9d4433fed7290f90a331f17c" class="src_link" title="app/models/evaluation.rb">app/models/evaluation.rb</a></td>
+        <td class="strong"><a href="#af050f8ae38bc7e6884bab52799ce53ef05446c4" class="src_link" title="app/models/evaluation.rb">app/models/evaluation.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>20</td>
         <td>18</td>
@@ -291,7 +291,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#a06b8312d493c33918013966dc6e231dad452ab1" class="src_link" title="app/models/meeting.rb">app/models/meeting.rb</a></td>
+        <td class="strong"><a href="#3d5bfb12dc5e003ffc28ab348fd5af6d4a15a4d9" class="src_link" title="app/models/meeting.rb">app/models/meeting.rb</a></td>
         <td class="yellow strong">88.89 %</td>
         <td>13</td>
         <td>9</td>
@@ -301,7 +301,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#d1f41e6d2ac68e6d020f2b459532d1d034f6dfb5" class="src_link" title="app/models/request.rb">app/models/request.rb</a></td>
+        <td class="strong"><a href="#1c6aeb75e7e22f97af9b0b060ed7ec8219d86510" class="src_link" title="app/models/request.rb">app/models/request.rb</a></td>
         <td class="yellow strong">87.5 %</td>
         <td>11</td>
         <td>8</td>
@@ -311,7 +311,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#6f1c6db58e84ab384da77bd2e24501c36decd7eb" class="src_link" title="app/models/tutee.rb">app/models/tutee.rb</a></td>
+        <td class="strong"><a href="#11f5addf455d0c3470bed0f640196fa3bc58e088" class="src_link" title="app/models/tutee.rb">app/models/tutee.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>101</td>
         <td>60</td>
@@ -321,7 +321,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#b113cbc4b89ebb17c37722a9a037e68c18659ab4" class="src_link" title="app/models/tutor.rb">app/models/tutor.rb</a></td>
+        <td class="strong"><a href="#6710fe3a668eb48fefaef23397f5c0593a6800b1" class="src_link" title="app/models/tutor.rb">app/models/tutor.rb</a></td>
         <td class="red strong">65.63 %</td>
         <td>46</td>
         <td>32</td>
@@ -331,7 +331,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#a026b7c087fdf4770f19267cf79398a4b36d8090" class="src_link" title="config/application.rb">config/application.rb</a></td>
+        <td class="strong"><a href="#4fee385904d202d5746d7942fc5538d2e7085d2f" class="src_link" title="config/application.rb">config/application.rb</a></td>
         <td class="green strong">95.24 %</td>
         <td>41</td>
         <td>21</td>
@@ -341,7 +341,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#650b852c920f608e7b28ed1c5adcff90e240c826" class="src_link" title="config/boot.rb">config/boot.rb</a></td>
+        <td class="strong"><a href="#5ab362a28bf8fbaaeffa3b6114cad125ed23f845" class="src_link" title="config/boot.rb">config/boot.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>4</td>
         <td>3</td>
@@ -351,7 +351,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#41b3055594e2c27828bc007edf473f6b23c3e034" class="src_link" title="config/environment.rb">config/environment.rb</a></td>
+        <td class="strong"><a href="#a619b5a6c041c8972ad217670c339249802eb984" class="src_link" title="config/environment.rb">config/environment.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>5</td>
         <td>2</td>
@@ -361,7 +361,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#45dff4e870289555106dbb04846b2f20bb5d9874" class="src_link" title="config/environments/test.rb">config/environments/test.rb</a></td>
+        <td class="strong"><a href="#e263112e4c0cfd27a255dfb79f409d175b2f9388" class="src_link" title="config/environments/test.rb">config/environments/test.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>47</td>
         <td>14</td>
@@ -371,7 +371,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#7f96744ec93720b10c020f64b2ce3d10cf30d1ca" class="src_link" title="config/initializers/application_controller_renderer.rb">config/initializers/application_controller_renderer.rb</a></td>
+        <td class="strong"><a href="#d600a244243d7fe02f944d63bf71190bb87adf12" class="src_link" title="config/initializers/application_controller_renderer.rb">config/initializers/application_controller_renderer.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>8</td>
         <td>0</td>
@@ -381,7 +381,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#669c57fd801262bc1eca06257db2ea76f846ce97" class="src_link" title="config/initializers/assets.rb">config/initializers/assets.rb</a></td>
+        <td class="strong"><a href="#0dc1b8640a96deafd14747e13fb90af835c9179f" class="src_link" title="config/initializers/assets.rb">config/initializers/assets.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>37</td>
         <td>13</td>
@@ -391,7 +391,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#86c9fe736c478c132175357e415f09057c9cb22f" class="src_link" title="config/initializers/backtrace_silencers.rb">config/initializers/backtrace_silencers.rb</a></td>
+        <td class="strong"><a href="#d35617669be7f6121763c58b8421e7ad7dd25ae1" class="src_link" title="config/initializers/backtrace_silencers.rb">config/initializers/backtrace_silencers.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>7</td>
         <td>0</td>
@@ -401,7 +401,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#8c23c254c5add7422077f0dffbd88bdcae4aefa3" class="src_link" title="config/initializers/content_security_policy.rb">config/initializers/content_security_policy.rb</a></td>
+        <td class="strong"><a href="#1afb11963ac5a27179ce9e0a3c9471234520c8bb" class="src_link" title="config/initializers/content_security_policy.rb">config/initializers/content_security_policy.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>25</td>
         <td>0</td>
@@ -411,7 +411,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#2014a789c0f1bbb9749f8254e50c595fce7756bb" class="src_link" title="config/initializers/cookies_serializer.rb">config/initializers/cookies_serializer.rb</a></td>
+        <td class="strong"><a href="#048235d13ade6a52fc3a89106ceb8e5991273dec" class="src_link" title="config/initializers/cookies_serializer.rb">config/initializers/cookies_serializer.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>5</td>
         <td>1</td>
@@ -421,7 +421,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#90d2e93d40f0a63eed06f24762e7bb6e99f60000" class="src_link" title="config/initializers/devise.rb">config/initializers/devise.rb</a></td>
+        <td class="strong"><a href="#b56039b851af8a49f344061c5cfd95b922a25c8c" class="src_link" title="config/initializers/devise.rb">config/initializers/devise.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>299</td>
         <td>15</td>
@@ -431,7 +431,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#94bb639936dc44aaf46b9363fce6284c70d06061" class="src_link" title="config/initializers/filter_parameter_logging.rb">config/initializers/filter_parameter_logging.rb</a></td>
+        <td class="strong"><a href="#1418b8eeb17e64474897dff66cbd94935cde2b9c" class="src_link" title="config/initializers/filter_parameter_logging.rb">config/initializers/filter_parameter_logging.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>4</td>
         <td>1</td>
@@ -441,7 +441,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#2f1857a4f6e793e01c337219abd8b8bb221c4680" class="src_link" title="config/initializers/inflections.rb">config/initializers/inflections.rb</a></td>
+        <td class="strong"><a href="#65aea274cf27ef10c1cce33ff5ec821dc447f422" class="src_link" title="config/initializers/inflections.rb">config/initializers/inflections.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>16</td>
         <td>0</td>
@@ -451,7 +451,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#12d98f3b79c7e3b406a427cb964988d8cb6c0e00" class="src_link" title="config/initializers/mime_types.rb">config/initializers/mime_types.rb</a></td>
+        <td class="strong"><a href="#e4a9aec1632a50b74544f207a79988e0ecdc2ad9" class="src_link" title="config/initializers/mime_types.rb">config/initializers/mime_types.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>4</td>
         <td>0</td>
@@ -461,7 +461,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#e50fe79f6dbbbd9fe24f6096e65082fa7ea97c35" class="src_link" title="config/initializers/setup_mail.rb">config/initializers/setup_mail.rb</a></td>
+        <td class="strong"><a href="#f1baabcf88f72f32c2372307f10442e8c05ed8b6" class="src_link" title="config/initializers/setup_mail.rb">config/initializers/setup_mail.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>9</td>
         <td>0</td>
@@ -471,7 +471,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#6bc89e4562d7369faf66e5bcca09f5e738432d6b" class="src_link" title="config/initializers/wrap_parameters.rb">config/initializers/wrap_parameters.rb</a></td>
+        <td class="strong"><a href="#0b28420dd8bab2ab01f73fea219a234938ee54ac" class="src_link" title="config/initializers/wrap_parameters.rb">config/initializers/wrap_parameters.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>14</td>
         <td>2</td>
@@ -481,7 +481,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#f2d089850d0420171a8572ab505a14539e265f95" class="src_link" title="config/routes.rb">config/routes.rb</a></td>
+        <td class="strong"><a href="#2e07a6389737e0e448b6a7f5af9e5e3ce2e73ff3" class="src_link" title="config/routes.rb">config/routes.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>63</td>
         <td>43</td>
@@ -491,7 +491,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#7e1cb99750c0361be6f1879c3cb343c5a9c9912e" class="src_link" title="features/step_definitions/tutors_steps.rb">features/step_definitions/tutors_steps.rb</a></td>
+        <td class="strong"><a href="#7a801f0a0f4ec2e7988cfea5bc074dbb1cba9576" class="src_link" title="features/step_definitions/tutors_steps.rb">features/step_definitions/tutors_steps.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>11</td>
         <td>6</td>
@@ -501,7 +501,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#cd7c47cc1a473bdb385bce3496b759966e220555" class="src_link" title="features/step_definitions/web_steps.rb">features/step_definitions/web_steps.rb</a></td>
+        <td class="strong"><a href="#36d39d3e39d39a32a1d8415d0aa55fdd8cf42b80" class="src_link" title="features/step_definitions/web_steps.rb">features/step_definitions/web_steps.rb</a></td>
         <td class="green strong">91.67 %</td>
         <td>278</td>
         <td>24</td>
@@ -511,7 +511,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#ee5d416283bd93619217f6c8e5c30aad4d558381" class="src_link" title="features/step_denifition/admin_steps.rb">features/step_denifition/admin_steps.rb</a></td>
+        <td class="strong"><a href="#ece1e100eedb0858565df157e06696b176ca14f4" class="src_link" title="features/step_denifition/admin_steps.rb">features/step_denifition/admin_steps.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>130</td>
         <td>78</td>
@@ -521,7 +521,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#845ee0c5bc42d1c3e52087f03107c0a4c3a2c86b" class="src_link" title="features/step_denifition/course_steps.rb">features/step_denifition/course_steps.rb</a></td>
+        <td class="strong"><a href="#840285ac31a615c7cdde613f15126c96452e49c2" class="src_link" title="features/step_denifition/course_steps.rb">features/step_denifition/course_steps.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>5</td>
         <td>3</td>
@@ -531,7 +531,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#6861c03d7aee2fa2138b07aebb1fd8f8c6dd1d00" class="src_link" title="features/step_denifition/evaluation_steps.rb">features/step_denifition/evaluation_steps.rb</a></td>
+        <td class="strong"><a href="#b83a606abc6c5ffb7a3d6e8253c9fdab98a07a68" class="src_link" title="features/step_denifition/evaluation_steps.rb">features/step_denifition/evaluation_steps.rb</a></td>
         <td class="green strong">93.18 %</td>
         <td>159</td>
         <td>88</td>
@@ -541,7 +541,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#50d7512d3a24f5d34532c5d80166fee4f6071a62" class="src_link" title="features/step_denifition/history_steps.rb">features/step_denifition/history_steps.rb</a></td>
+        <td class="strong"><a href="#f57029296b1a0608c219edcd0d282952a34d3b6b" class="src_link" title="features/step_denifition/history_steps.rb">features/step_denifition/history_steps.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>16</td>
         <td>8</td>
@@ -551,7 +551,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#b3ef0b9a5c6e0893341ed6c461e27acba107c545" class="src_link" title="features/step_denifition/request_steps.rb">features/step_denifition/request_steps.rb</a></td>
+        <td class="strong"><a href="#0251ca84c7ffb201b9000239f9d4a29c67535419" class="src_link" title="features/step_denifition/request_steps.rb">features/step_denifition/request_steps.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>36</td>
         <td>20</td>
@@ -561,7 +561,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#faf42076eee8925d4e0b1ece682ad11f6e269972" class="src_link" title="features/step_denifition/support_steps.rb">features/step_denifition/support_steps.rb</a></td>
+        <td class="strong"><a href="#dffdd31e8dd6a367a3d346b3a5d5f90a7aee9aef" class="src_link" title="features/step_denifition/support_steps.rb">features/step_denifition/support_steps.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>4</td>
         <td>0</td>
@@ -571,7 +571,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#783a7f10cbebe5bb3ffc8cda0874eb1c9150e7c4" class="src_link" title="features/step_denifition/tutee_steps.rb">features/step_denifition/tutee_steps.rb</a></td>
+        <td class="strong"><a href="#e6d97406f16d5a339dddcf618234a6f71baf0297" class="src_link" title="features/step_denifition/tutee_steps.rb">features/step_denifition/tutee_steps.rb</a></td>
         <td class="green strong">94.29 %</td>
         <td>74</td>
         <td>35</td>
@@ -581,7 +581,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#3301fcdf4b19dc2f2bba4994feb707cea6a4149e" class="src_link" title="features/step_denifition/web_steps.rb">features/step_denifition/web_steps.rb</a></td>
+        <td class="strong"><a href="#b9af1e586ae32a3743cb017761a40de6a5f46273" class="src_link" title="features/step_denifition/web_steps.rb">features/step_denifition/web_steps.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>3</td>
         <td>0</td>
@@ -591,7 +591,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#bd764ab7f1597e138b783e82d36acd477b97beef" class="src_link" title="features/support/paths.rb">features/support/paths.rb</a></td>
+        <td class="strong"><a href="#dd8991188306411d9d0f50b3298f21cb4ef1cf43" class="src_link" title="features/support/paths.rb">features/support/paths.rb</a></td>
         <td class="green strong">90.91 %</td>
         <td>92</td>
         <td>33</td>
@@ -601,7 +601,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#9676871e82061a50e2c6ce8bd6101458a40efb26" class="src_link" title="features/support/selectors.rb">features/support/selectors.rb</a></td>
+        <td class="strong"><a href="#5742614e228b84726962b0a6756a361886009402" class="src_link" title="features/support/selectors.rb">features/support/selectors.rb</a></td>
         <td class="red strong">42.86 %</td>
         <td>48</td>
         <td>7</td>
@@ -611,7 +611,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#b02036a06eeeddc42c1494674a7cd7793d9d632b" class="src_link" title="spec/factories/admins.rb">spec/factories/admins.rb</a></td>
+        <td class="strong"><a href="#6bc1eb64dc10ed85de0856596a2e7d85b78d278f" class="src_link" title="spec/factories/admins.rb">spec/factories/admins.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>7</td>
         <td>5</td>
@@ -621,7 +621,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#9a66728ef334f4807d4be60d66abe34aed2f93a8" class="src_link" title="spec/factories/core.rb">spec/factories/core.rb</a></td>
+        <td class="strong"><a href="#2b60a2b026983793d24368c9d1f73e326f62e908" class="src_link" title="spec/factories/core.rb">spec/factories/core.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>22</td>
         <td>13</td>
@@ -631,7 +631,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#ed456db281e9883217ba6c8c5b36c73e67aca26b" class="src_link" title="spec/factories/courses.rb">spec/factories/courses.rb</a></td>
+        <td class="strong"><a href="#5edfdd7f3d4ad0d7356b223efdf87c3bd3869278" class="src_link" title="spec/factories/courses.rb">spec/factories/courses.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>7</td>
         <td>2</td>
@@ -641,7 +641,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#ed1b6f5626733c923d46512f3a86d56daa3ca033" class="src_link" title="spec/factories/evaluations.rb">spec/factories/evaluations.rb</a></td>
+        <td class="strong"><a href="#c80646bddf20365fd87be0d0ee6baaa1492ce3cc" class="src_link" title="spec/factories/evaluations.rb">spec/factories/evaluations.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>6</td>
         <td>4</td>
@@ -651,7 +651,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#7949e0b862cad1477cd473fa03d33ca4983881bc" class="src_link" title="spec/factories/tutees.rb">spec/factories/tutees.rb</a></td>
+        <td class="strong"><a href="#eb3ec93f6476d5efd058f9ef4db6fd6a999bd93c" class="src_link" title="spec/factories/tutees.rb">spec/factories/tutees.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>141</td>
         <td>122</td>
@@ -661,7 +661,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#8ecab71feacd0062ef4582655419a66a8a9e9444" class="src_link" title="spec/factories/tutors.rb">spec/factories/tutors.rb</a></td>
+        <td class="strong"><a href="#66e31ab48741e13de8f968594259c461187fa2a3" class="src_link" title="spec/factories/tutors.rb">spec/factories/tutors.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>0</td>
         <td>0</td>
@@ -686,7 +686,7 @@
     
       <div class="source_files">
       
-        <div class="source_table" id="26463c231c580ceb270824e18bbe5ff01911c6ac">
+        <div class="source_table" id="510b765e2df081cf54826c9cf6a4c5355f04c390">
   <div class="header">
     <h3>app/controllers/admins_controller.rb</h3>
     <h4><span class="green">94.4 %</span> covered</h4>
@@ -1965,7 +1965,7 @@
 </div>
 
       
-        <div class="source_table" id="deb1544369d2b944365327c02b6185c2c171cc09">
+        <div class="source_table" id="348beacf8f7812cef945c615b627da2290d063c9">
   <div class="header">
     <h3>app/controllers/application_controller.rb</h3>
     <h4><span class="green">97.62 %</span> covered</h4>
@@ -2398,7 +2398,7 @@
 </div>
 
       
-        <div class="source_table" id="b5fb3d324d2acbdaa2bc00feaf2285278e5aa25f">
+        <div class="source_table" id="3d40176ccfe2c3a853fc03d671a10d1634b48db2">
   <div class="header">
     <h3>app/controllers/concerns/friendlyable.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -2513,7 +2513,7 @@
 </div>
 
       
-        <div class="source_table" id="2dc131ec131b9be95156a4bc77cbf698519fe74f">
+        <div class="source_table" id="57dd48fbe1fdafeb41d65c6ceb67f360340b5962">
   <div class="header">
     <h3>app/controllers/evaluations_controller.rb</h3>
     <h4><span class="green">91.89 %</span> covered</h4>
@@ -2922,7 +2922,7 @@
 </div>
 
       
-        <div class="source_table" id="ac28a37c753dec5f383ed99f7c7084fa7c6c6571">
+        <div class="source_table" id="2106888026f42fd22c735d957f561e0af1c320f4">
   <div class="header">
     <h3>app/controllers/meetings_controller.rb</h3>
     <h4><span class="yellow">89.74 %</span> covered</h4>
@@ -3313,7 +3313,7 @@
 </div>
 
       
-        <div class="source_table" id="932021a8f8c5ed62e3f0d175ddf50739ab3e035d">
+        <div class="source_table" id="72de3d9e237bb4471a855f9c8201c651be77820a">
   <div class="header">
     <h3>app/controllers/requests_controller.rb</h3>
     <h4><span class="red">50.0 %</span> covered</h4>
@@ -4070,7 +4070,7 @@
 </div>
 
       
-        <div class="source_table" id="6b20b2772ab1342c1afcc3a0a476461fabbfc224">
+        <div class="source_table" id="e64874275626fcc3ae8959a26f21a3468340e4ae">
   <div class="header">
     <h3>app/controllers/tutees/registrations_controller.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -4599,7 +4599,7 @@
 </div>
 
       
-        <div class="source_table" id="524a6d064aff187c5c208a80e218684f4bd44de7">
+        <div class="source_table" id="ad677769a193cf4943352f9262ea6dac4d146740">
   <div class="header">
     <h3>app/controllers/tutees_controller.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -4870,7 +4870,7 @@
 </div>
 
       
-        <div class="source_table" id="66ec2ac933ea6d38096d79e24af1654ce81c8ec5">
+        <div class="source_table" id="d9c28fab816d4b19ddacefad3fd3e700e02500e1">
   <div class="header">
     <h3>app/controllers/tutors/registrations_controller.rb</h3>
     <h4><span class="yellow">84.85 %</span> covered</h4>
@@ -5196,8 +5196,8 @@
           <code class="ruby">    BerkeleyClass.all_classes.each do |current_class|</code>
         </li>
       
-        <li class="covered" data-hits="9" data-linenumber="53">
-          <span class="hits">9</span>
+        <li class="covered" data-hits="11" data-linenumber="53">
+          <span class="hits">11</span>
           
           <code class="ruby">      params[:classes][current_class] = params[:classes].has_key?(current_class) #true hash string =&gt; all hash boolean</code>
         </li>
@@ -5211,7 +5211,7 @@
         <li class="covered" data-hits="1" data-linenumber="55">
           <span class="hits">1</span>
           
-          <code class="ruby">   params.require(:classes).permit(:CS61A, :CS61B, :CS61C, :CS70, :EE16A, :EE16B, :CS88, :CS10, :DATA8) #maybe store this list as a constant</code>
+          <code class="ruby">   params.require(:classes).permit(:CS61A, :CS61B, :CS61C, :CS70, :EE16A, :EE16B, :CS88, :CS10, :DATA8, :UPPERDIV, :OTHER) #maybe store this list as a constant</code>
         </li>
       
         <li class="never" data-hits="" data-linenumber="56">
@@ -5537,7 +5537,7 @@
 </div>
 
       
-        <div class="source_table" id="3c314adbf60036b9b6074fb2b5d3353691f4ea61">
+        <div class="source_table" id="60a689a886f70e3641bfa2e100503f5046712f66">
   <div class="header">
     <h3>app/controllers/tutors_controller.rb</h3>
     <h4><span class="red">76.14 %</span> covered</h4>
@@ -6481,8 +6481,8 @@
           <code class="ruby">      BerkeleyClass.all_classes.each do |current_class|</code>
         </li>
       
-        <li class="covered" data-hits="18" data-linenumber="156">
-          <span class="hits">18</span>
+        <li class="covered" data-hits="22" data-linenumber="156">
+          <span class="hits">22</span>
           
           <code class="ruby">        params[:classes][current_class] = params[:classes].has_key?(current_class) #true hash string =&gt; all hash boolean</code>
         </li>
@@ -6496,7 +6496,7 @@
         <li class="covered" data-hits="2" data-linenumber="158">
           <span class="hits">2</span>
           
-          <code class="ruby">     params.require(:classes).permit(:CS61A, :CS61B, :CS61C, :CS70, :EE16A, :EE16B, :CS88, :CS10, :DATA8) #maybe store this list as a constant</code>
+          <code class="ruby">     params.require(:classes).permit(:CS61A, :CS61B, :CS61C, :CS70, :EE16A, :EE16B, :CS88, :CS10, :DATA8, :UPPERDIV, :OTHER) #maybe store this list as a constant</code>
         </li>
       
         <li class="never" data-hits="" data-linenumber="159">
@@ -6528,7 +6528,7 @@
 </div>
 
       
-        <div class="source_table" id="f06df8ccd52345012d0ad9b304349601da1e107e">
+        <div class="source_table" id="3d734bc430266f3cf802e2b243612cf78677c6e5">
   <div class="header">
     <h3>app/controllers/welcome_controller.rb</h3>
     <h4><span class="red">31.25 %</span> covered</h4>
@@ -6703,7 +6703,7 @@
 </div>
 
       
-        <div class="source_table" id="5975818c13bc92d2fb951b5f1f5cc20cfd8502c9">
+        <div class="source_table" id="941c942065a544ef86c6903f70711a8b43bd1e07">
   <div class="header">
     <h3>app/helpers/admins_helper.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -6734,7 +6734,7 @@
 </div>
 
       
-        <div class="source_table" id="157ad42dedfca6052397934d1e6eebcae5b4dd40">
+        <div class="source_table" id="aeface27f87e8e7135585072dac682c128d014ae">
   <div class="header">
     <h3>app/helpers/application_helper.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -6765,7 +6765,7 @@
 </div>
 
       
-        <div class="source_table" id="0500870e5011744fa2d267fefc77606811ae5d3d">
+        <div class="source_table" id="01f96cf5d377b020d9d6503a655f54c297179749">
   <div class="header">
     <h3>app/helpers/courses_helper.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -6796,7 +6796,7 @@
 </div>
 
       
-        <div class="source_table" id="ee840b6e77149293e2cbb55a91b7b554bc398886">
+        <div class="source_table" id="1ad11c446b3eed5f28adac5c36ca87826b2ac8ae">
   <div class="header">
     <h3>app/helpers/evaluations_helper.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -6827,7 +6827,7 @@
 </div>
 
       
-        <div class="source_table" id="d61ada6e6be49a1e013bf9dc24b962f23be58a7d">
+        <div class="source_table" id="3bad6a647f680ea5e325d559327041e367c2e606">
   <div class="header">
     <h3>app/helpers/requests_helper.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -6858,7 +6858,7 @@
 </div>
 
       
-        <div class="source_table" id="6c2235a720ab247c02c3f5d721ba7098867caed4">
+        <div class="source_table" id="6bbeb1a8170ef3e6279eb7e8e9ee79e86953d432">
   <div class="header">
     <h3>app/helpers/tutees_helper.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -6889,7 +6889,7 @@
 </div>
 
       
-        <div class="source_table" id="eada9445989d0eeb8bd69869dfa7582fe658d6f8">
+        <div class="source_table" id="1252bf43368e240153c365483e422901a8201ab8">
   <div class="header">
     <h3>app/helpers/tutors_helper.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -6920,7 +6920,7 @@
 </div>
 
       
-        <div class="source_table" id="a2c664dea4ddef56052d946c1476a954a8770a87">
+        <div class="source_table" id="eaa6ad621a726edee813fd1c8463a2f0e0a73ade">
   <div class="header">
     <h3>app/helpers/welcome_helper.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -6951,7 +6951,7 @@
 </div>
 
       
-        <div class="source_table" id="ed8eb0e3b50404db2f47123f1a5cfa375edb7c0c">
+        <div class="source_table" id="0419fecf8940bf36f80977d62bf4f5807a1062c4">
   <div class="header">
     <h3>app/models/admin.rb</h3>
     <h4><span class="green">90.48 %</span> covered</h4>
@@ -7228,7 +7228,7 @@
 </div>
 
       
-        <div class="source_table" id="23394b3f34a64f526639f3bf44d9b73f35adbdea">
+        <div class="source_table" id="3922d29b804811c40702288b75f3e6415da00413">
   <div class="header">
     <h3>app/models/application_record.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -7265,7 +7265,7 @@
 </div>
 
       
-        <div class="source_table" id="6a19aefe4ad708ce3fb1f629b0687b1e78a14c61">
+        <div class="source_table" id="95ab858a67083526fabd9d80b077e16d3d000ddb">
   <div class="header">
     <h3>app/models/berkeley_class.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -7309,8 +7309,8 @@
           <code class="ruby">		self.attributes.each_pair do |name, value|</code>
         </li>
       
-        <li class="covered" data-hits="160" data-linenumber="6">
-          <span class="hits">160</span>
+        <li class="covered" data-hits="192" data-linenumber="6">
+          <span class="hits">192</span>
           
           <code class="ruby">	      	if value == true</code>
         </li>
@@ -7369,8 +7369,8 @@
           <code class="ruby">		BerkeleyClass.column_names.each do |colunm_name|</code>
         </li>
       
-        <li class="covered" data-hits="210" data-linenumber="16">
-          <span class="hits">210</span>
+        <li class="covered" data-hits="252" data-linenumber="16">
+          <span class="hits">252</span>
           
           <code class="ruby">			@classes.push(colunm_name) if colunm_name != &quot;id&quot;</code>
         </li>
@@ -7410,7 +7410,7 @@
 </div>
 
       
-        <div class="source_table" id="c36bb0d35cb766151604bff00688dbba1e12b94d">
+        <div class="source_table" id="9247d3bf5a04545e69457bfd27d4c3b898b47014">
   <div class="header">
     <h3>app/models/course.rb</h3>
     <h4><span class="green">95.65 %</span> covered</h4>
@@ -7747,7 +7747,7 @@
 </div>
 
       
-        <div class="source_table" id="a8dab1bd2236a88b9d4433fed7290f90a331f17c">
+        <div class="source_table" id="af050f8ae38bc7e6884bab52799ce53ef05446c4">
   <div class="header">
     <h3>app/models/evaluation.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -7886,7 +7886,7 @@
 </div>
 
       
-        <div class="source_table" id="a06b8312d493c33918013966dc6e231dad452ab1">
+        <div class="source_table" id="3d5bfb12dc5e003ffc28ab348fd5af6d4a15a4d9">
   <div class="header">
     <h3>app/models/meeting.rb</h3>
     <h4><span class="yellow">88.89 %</span> covered</h4>
@@ -7983,7 +7983,7 @@
 </div>
 
       
-        <div class="source_table" id="d1f41e6d2ac68e6d020f2b459532d1d034f6dfb5">
+        <div class="source_table" id="1c6aeb75e7e22f97af9b0b060ed7ec8219d86510">
   <div class="header">
     <h3>app/models/request.rb</h3>
     <h4><span class="yellow">87.5 %</span> covered</h4>
@@ -8068,7 +8068,7 @@
 </div>
 
       
-        <div class="source_table" id="6f1c6db58e84ab384da77bd2e24501c36decd7eb">
+        <div class="source_table" id="11f5addf455d0c3470bed0f640196fa3bc58e088">
   <div class="header">
     <h3>app/models/tutee.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -8693,7 +8693,7 @@
 </div>
 
       
-        <div class="source_table" id="b113cbc4b89ebb17c37722a9a037e68c18659ab4">
+        <div class="source_table" id="6710fe3a668eb48fefaef23397f5c0593a6800b1">
   <div class="header">
     <h3>app/models/tutor.rb</h3>
     <h4><span class="red">65.63 %</span> covered</h4>
@@ -8988,7 +8988,7 @@
 </div>
 
       
-        <div class="source_table" id="a026b7c087fdf4770f19267cf79398a4b36d8090">
+        <div class="source_table" id="4fee385904d202d5746d7942fc5538d2e7085d2f">
   <div class="header">
     <h3>config/application.rb</h3>
     <h4><span class="green">95.24 %</span> covered</h4>
@@ -9253,7 +9253,7 @@
 </div>
 
       
-        <div class="source_table" id="650b852c920f608e7b28ed1c5adcff90e240c826">
+        <div class="source_table" id="5ab362a28bf8fbaaeffa3b6114cad125ed23f845">
   <div class="header">
     <h3>config/boot.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -9296,7 +9296,7 @@
 </div>
 
       
-        <div class="source_table" id="41b3055594e2c27828bc007edf473f6b23c3e034">
+        <div class="source_table" id="a619b5a6c041c8972ad217670c339249802eb984">
   <div class="header">
     <h3>config/environment.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -9345,7 +9345,7 @@
 </div>
 
       
-        <div class="source_table" id="45dff4e870289555106dbb04846b2f20bb5d9874">
+        <div class="source_table" id="e263112e4c0cfd27a255dfb79f409d175b2f9388">
   <div class="header">
     <h3>config/environments/test.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -9646,7 +9646,7 @@
 </div>
 
       
-        <div class="source_table" id="7f96744ec93720b10c020f64b2ce3d10cf30d1ca">
+        <div class="source_table" id="d600a244243d7fe02f944d63bf71190bb87adf12">
   <div class="header">
     <h3>config/initializers/application_controller_renderer.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -9713,7 +9713,7 @@
 </div>
 
       
-        <div class="source_table" id="669c57fd801262bc1eca06257db2ea76f846ce97">
+        <div class="source_table" id="0dc1b8640a96deafd14747e13fb90af835c9179f">
   <div class="header">
     <h3>config/initializers/assets.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -9954,7 +9954,7 @@
 </div>
 
       
-        <div class="source_table" id="86c9fe736c478c132175357e415f09057c9cb22f">
+        <div class="source_table" id="d35617669be7f6121763c58b8421e7ad7dd25ae1">
   <div class="header">
     <h3>config/initializers/backtrace_silencers.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -10015,7 +10015,7 @@
 </div>
 
       
-        <div class="source_table" id="8c23c254c5add7422077f0dffbd88bdcae4aefa3">
+        <div class="source_table" id="1afb11963ac5a27179ce9e0a3c9471234520c8bb">
   <div class="header">
     <h3>config/initializers/content_security_policy.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -10184,7 +10184,7 @@
 </div>
 
       
-        <div class="source_table" id="2014a789c0f1bbb9749f8254e50c595fce7756bb">
+        <div class="source_table" id="048235d13ade6a52fc3a89106ceb8e5991273dec">
   <div class="header">
     <h3>config/initializers/cookies_serializer.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -10233,7 +10233,7 @@
 </div>
 
       
-        <div class="source_table" id="90d2e93d40f0a63eed06f24762e7bb6e99f60000">
+        <div class="source_table" id="b56039b851af8a49f344061c5cfd95b922a25c8c">
   <div class="header">
     <h3>config/initializers/devise.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -12046,7 +12046,7 @@
 </div>
 
       
-        <div class="source_table" id="94bb639936dc44aaf46b9363fce6284c70d06061">
+        <div class="source_table" id="1418b8eeb17e64474897dff66cbd94935cde2b9c">
   <div class="header">
     <h3>config/initializers/filter_parameter_logging.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -12089,7 +12089,7 @@
 </div>
 
       
-        <div class="source_table" id="2f1857a4f6e793e01c337219abd8b8bb221c4680">
+        <div class="source_table" id="65aea274cf27ef10c1cce33ff5ec821dc447f422">
   <div class="header">
     <h3>config/initializers/inflections.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -12204,7 +12204,7 @@
 </div>
 
       
-        <div class="source_table" id="12d98f3b79c7e3b406a427cb964988d8cb6c0e00">
+        <div class="source_table" id="e4a9aec1632a50b74544f207a79988e0ecdc2ad9">
   <div class="header">
     <h3>config/initializers/mime_types.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -12247,7 +12247,7 @@
 </div>
 
       
-        <div class="source_table" id="e50fe79f6dbbbd9fe24f6096e65082fa7ea97c35">
+        <div class="source_table" id="f1baabcf88f72f32c2372307f10442e8c05ed8b6">
   <div class="header">
     <h3>config/initializers/setup_mail.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -12320,7 +12320,7 @@
 </div>
 
       
-        <div class="source_table" id="6bc89e4562d7369faf66e5bcca09f5e738432d6b">
+        <div class="source_table" id="0b28420dd8bab2ab01f73fea219a234938ee54ac">
   <div class="header">
     <h3>config/initializers/wrap_parameters.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -12423,7 +12423,7 @@
 </div>
 
       
-        <div class="source_table" id="f2d089850d0420171a8572ab505a14539e265f95">
+        <div class="source_table" id="2e07a6389737e0e448b6a7f5af9e5e3ce2e73ff3">
   <div class="header">
     <h3>config/routes.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -12820,7 +12820,7 @@
 </div>
 
       
-        <div class="source_table" id="7e1cb99750c0361be6f1879c3cb343c5a9c9912e">
+        <div class="source_table" id="7a801f0a0f4ec2e7988cfea5bc074dbb1cba9576">
   <div class="header">
     <h3>features/step_definitions/tutors_steps.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -12905,7 +12905,7 @@
 </div>
 
       
-        <div class="source_table" id="cd7c47cc1a473bdb385bce3496b759966e220555">
+        <div class="source_table" id="36d39d3e39d39a32a1d8415d0aa55fdd8cf42b80">
   <div class="header">
     <h3>features/step_definitions/web_steps.rb</h3>
     <h4><span class="green">91.67 %</span> covered</h4>
@@ -14592,7 +14592,7 @@
 </div>
 
       
-        <div class="source_table" id="ee5d416283bd93619217f6c8e5c30aad4d558381">
+        <div class="source_table" id="ece1e100eedb0858565df157e06696b176ca14f4">
   <div class="header">
     <h3>features/step_denifition/admin_steps.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -15391,7 +15391,7 @@
 </div>
 
       
-        <div class="source_table" id="845ee0c5bc42d1c3e52087f03107c0a4c3a2c86b">
+        <div class="source_table" id="840285ac31a615c7cdde613f15126c96452e49c2">
   <div class="header">
     <h3>features/step_denifition/course_steps.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -15440,7 +15440,7 @@
 </div>
 
       
-        <div class="source_table" id="6861c03d7aee2fa2138b07aebb1fd8f8c6dd1d00">
+        <div class="source_table" id="b83a606abc6c5ffb7a3d6e8253c9fdab98a07a68">
   <div class="header">
     <h3>features/step_denifition/evaluation_steps.rb</h3>
     <h4><span class="green">93.18 %</span> covered</h4>
@@ -16413,7 +16413,7 @@
 </div>
 
       
-        <div class="source_table" id="50d7512d3a24f5d34532c5d80166fee4f6071a62">
+        <div class="source_table" id="f57029296b1a0608c219edcd0d282952a34d3b6b">
   <div class="header">
     <h3>features/step_denifition/history_steps.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -16528,7 +16528,7 @@
 </div>
 
       
-        <div class="source_table" id="b3ef0b9a5c6e0893341ed6c461e27acba107c545">
+        <div class="source_table" id="0251ca84c7ffb201b9000239f9d4a29c67535419">
   <div class="header">
     <h3>features/step_denifition/request_steps.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -16763,7 +16763,7 @@
 </div>
 
       
-        <div class="source_table" id="faf42076eee8925d4e0b1ece682ad11f6e269972">
+        <div class="source_table" id="dffdd31e8dd6a367a3d346b3a5d5f90a7aee9aef">
   <div class="header">
     <h3>features/step_denifition/support_steps.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -16806,7 +16806,7 @@
 </div>
 
       
-        <div class="source_table" id="783a7f10cbebe5bb3ffc8cda0874eb1c9150e7c4">
+        <div class="source_table" id="e6d97406f16d5a339dddcf618234a6f71baf0297">
   <div class="header">
     <h3>features/step_denifition/tutee_steps.rb</h3>
     <h4><span class="green">94.29 %</span> covered</h4>
@@ -17269,7 +17269,7 @@
 </div>
 
       
-        <div class="source_table" id="3301fcdf4b19dc2f2bba4994feb707cea6a4149e">
+        <div class="source_table" id="b9af1e586ae32a3743cb017761a40de6a5f46273">
   <div class="header">
     <h3>features/step_denifition/web_steps.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -17306,7 +17306,7 @@
 </div>
 
       
-        <div class="source_table" id="bd764ab7f1597e138b783e82d36acd477b97beef">
+        <div class="source_table" id="dd8991188306411d9d0f50b3298f21cb4ef1cf43">
   <div class="header">
     <h3>features/support/paths.rb</h3>
     <h4><span class="green">90.91 %</span> covered</h4>
@@ -17877,7 +17877,7 @@
 </div>
 
       
-        <div class="source_table" id="9676871e82061a50e2c6ce8bd6101458a40efb26">
+        <div class="source_table" id="5742614e228b84726962b0a6756a361886009402">
   <div class="header">
     <h3>features/support/selectors.rb</h3>
     <h4><span class="red">42.86 %</span> covered</h4>
@@ -18184,7 +18184,7 @@
 </div>
 
       
-        <div class="source_table" id="b02036a06eeeddc42c1494674a7cd7793d9d632b">
+        <div class="source_table" id="6bc1eb64dc10ed85de0856596a2e7d85b78d278f">
   <div class="header">
     <h3>spec/factories/admins.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -18245,7 +18245,7 @@
 </div>
 
       
-        <div class="source_table" id="9a66728ef334f4807d4be60d66abe34aed2f93a8">
+        <div class="source_table" id="2b60a2b026983793d24368c9d1f73e326f62e908">
   <div class="header">
     <h3>spec/factories/core.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -18396,7 +18396,7 @@
 </div>
 
       
-        <div class="source_table" id="ed456db281e9883217ba6c8c5b36c73e67aca26b">
+        <div class="source_table" id="5edfdd7f3d4ad0d7356b223efdf87c3bd3869278">
   <div class="header">
     <h3>spec/factories/courses.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -18457,7 +18457,7 @@
 </div>
 
       
-        <div class="source_table" id="ed1b6f5626733c923d46512f3a86d56daa3ca033">
+        <div class="source_table" id="c80646bddf20365fd87be0d0ee6baaa1492ce3cc">
   <div class="header">
     <h3>spec/factories/evaluations.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -18512,7 +18512,7 @@
 </div>
 
       
-        <div class="source_table" id="7949e0b862cad1477cd473fa03d33ca4983881bc">
+        <div class="source_table" id="eb3ec93f6476d5efd058f9ef4db6fd6a999bd93c">
   <div class="header">
     <h3>spec/factories/tutees.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -19377,7 +19377,7 @@
 </div>
 
       
-        <div class="source_table" id="8ecab71feacd0062ef4582655419a66a8a9e9444">
+        <div class="source_table" id="66e31ab48741e13de8f968594259c461187fa2a3">
   <div class="header">
     <h3>spec/factories/tutors.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>

--- a/db/migrate/20191214011423_add_upper_div_and_other_to_berkeley_classes.rb
+++ b/db/migrate/20191214011423_add_upper_div_and_other_to_berkeley_classes.rb
@@ -1,0 +1,6 @@
+class AddUpperDivAndOtherToBerkeleyClasses < ActiveRecord::Migration[5.2]
+  def change
+    add_column :berkeley_classes, :UPPERDIV, :boolean, default: false 
+    add_column :berkeley_classes, :OTHER, :boolean, default: false 
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_12_195514) do
+ActiveRecord::Schema.define(version: 2019_12_14_011423) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,6 +33,8 @@ ActiveRecord::Schema.define(version: 2019_12_12_195514) do
     t.boolean "CS10"
     t.boolean "DATA8"
     t.boolean "EE16B", default: false
+    t.boolean "UPPERDIV", default: false
+    t.boolean "OTHER", default: false
   end
 
   create_table "courses", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -20,7 +20,7 @@ courses = [{:course_num => 1, :name => "CS61A", :semester => "Sp2019"},
 # evaluations = [{:knowledgeable=>5, :helpful=> 4, :clarity=>4, :final_comments => 'woopdy di scoop woop'},
 # 							 {:knowledgeable=>4, :helpful=> 4, :clarity=>4, :final_comments => 'awesome'},
 # 							 {:knowledgeable=>5, :helpful=> 5, :clarity=>4, :final_comments => 'cool'}]
-course_list = ["CS10", "CS61A", "CS61B", "CS61C", "CS70", "CS88", "EE16A", "EE16B", "DATA8"]
+course_list = ["CS10", "CS61A", "CS61B", "CS61C", "CS70", "CS88", "EE16A", "EE16B", "DATA8", "UPPERDIV", "OTHER"]
 # tutee_cs_scholar = {:sid => 123456789, :first_name => "Peter", :last_name => "Griffin", :email => "alvinnguyen@berkeley.edu", :birthdate => "1992-01-01", :privilege => 'cs61a', :gender => 'male',
 #                     :ethnicity => 'Asian', :dsp => 'Yes', :transfer => 'Yes', :year => '4+', :pronoun => 'he/his', :major => 'EECS'}
 # tutee_not_cs_scholar = {:sid => 123456789, :first_name => "Naruto", :last_name => "Uzumaki", :email => "bobs@berkeley.edu", :birthdate => Time.now, :privilege => 'No', :gender => 'male',
@@ -83,7 +83,9 @@ BerkeleyClass.create!(
   EE16B: true,
   CS88: true,
   CS10: true,
-  DATA8: true
+  DATA8: true,
+  UPPERDIV: true,
+  OTHER: true
 )
 
 # 10.times do


### PR DESCRIPTION
# Add UPPERDIV and OTHER as class options

## Purpose

The purpose of this Pull Request is to add the ability for the admin to enable UPPERDIV and OTHER as course options. By default, these courses will be disabled and the admin will need to manually enable them from the admin dashboard

## User Story

- As a admin
- So that I can expand our offerings
- Then I should be able to set UPPERDIV and OTHER as class options
