### PR TITLE
Fixed bug where student can fill eval before meeting

### DIFF
--- a/app/controllers/evaluations_controller.rb
+++ b/app/controllers/evaluations_controller.rb
@@ -56,6 +56,8 @@ class EvaluationsController < ApplicationController
 
   def public_edit
      @evaluation = Evaluation.find_by_hash_id params[:id]
+     @meeting = Meeting.where("evaluation_id = ?", params[:id])
+     @is_eval_available = @meeting.set_time < Time.now
   end
 
   def public_show

--- a/app/controllers/evaluations_controller.rb
+++ b/app/controllers/evaluations_controller.rb
@@ -10,6 +10,12 @@ class EvaluationsController < ApplicationController
   def edit
     @tutee = Tutee.find params[:tutee_id]
     @evaluation = Evaluation.friendly.find params[:id]
+    @meeting = Meeting.where("evaluation_id = ?", @evaluation.id).first
+    if not @meeting.nil? and not @meeting.set_time.nil?
+      @is_eval_available = @meeting.set_time < Time.now
+    else
+      @is_eval_available = true
+    end
   end
 
   def update
@@ -56,8 +62,6 @@ class EvaluationsController < ApplicationController
 
   def public_edit
      @evaluation = Evaluation.find_by_hash_id params[:id]
-     @meeting = Meeting.where("evaluation_id = ?", params[:id])
-     @is_eval_available = @meeting.set_time < Time.now
   end
 
   def public_show

--- a/app/views/evaluations/edit.html.haml
+++ b/app/views/evaluations/edit.html.haml
@@ -15,169 +15,173 @@
       - if flash[:message]
         .alert.alert-danger
           %span.error= flash[:message]
+      - if not @is_eval_available
+        .card.mb-3
+          .card-header
+            You can only fill in the evaluation form after the scheduled meeting.
+      -else
+        = form_tag tutee_evaluation_path(@tutee, @evaluation), :method => :put, class: 'container-fluid' do
+          .form-group
+            %h3.font-weight-bold Tutor: #{@evaluation.tutor.first_name}
+            .form-row
+              .form-group.col-md-8
+                %span Did you meet your tutor in person?
+                = label :evaluation, :took_place, 'Yes'
+                = radio_button :evaluation, 'took_place', true, id: 'radioButton2',
+                :onclick => "document.getElementById('disabled1').disabled=!this.checked;document.getElementById('disabled2').disabled=!this.checked;document.getElementById('disabled3').disabled=!this.checked;document.getElementById('disabled4').disabled=!this.checked;document.getElementById('disabled5').disabled=!this.checked;document.getElementById('disabled6').disabled=!this.checked;document.getElementById('disabled7').disabled=!this.checked;document.getElementById('disabled8').disabled=!this.checked;document.getElementById('disabled9').disabled=!this.checked;document.getElementById('disabled10').disabled=!this.checked;document.getElementById('disabled11').disabled=!this.checked;document.getElementById('disabled12').disabled=!this.checked;document.getElementById('disabled13').disabled=!this.checked;document.getElementById('disabled14').disabled=!this.checked;document.getElementById('disabled15').disabled=!this.checked;document.getElementById('disabled16').disabled=!this.checked;document.getElementById('disabled17').disabled=!this.checked;document.getElementById('disabled18').disabled=!this.checked;document.getElementById('disabled19').disabled=!this.checked;document.getElementById('disabled20').disabled=!this.checked;document.getElementById('disabled21').disabled=!this.checked;document.getElementById('disabled22').disabled=!this.checked;document.getElementById('disabled23').disabled=!this.checked;document.getElementById('disabled24').disabled=!this.checked;document.getElementById('disabled25').disabled=!this.checked;document.getElementById('disabled26').disabled=!this.checked;document.getElementById('disabled27').disabled=!this.checked;document.getElementById('disabled28').disabled=!this.checked;document.getElementById('disabled29').disabled=!this.checked;document.getElementById('disabled30').disabled=!this.checked;document.getElementById('disabled31').disabled=!this.checked;document.getElementById('disabled32').disabled=!this.checked"
+                = label :evaluation, :took_place, 'No'
+                = radio_button :evaluation, 'took_place', false, id: 'radioButton',
+                :onclick => "document.getElementById('disabled1').disabled=this.checked;document.getElementById('disabled2').disabled=this.checked;document.getElementById('disabled3').disabled=this.checked;document.getElementById('disabled4').disabled=this.checked;document.getElementById('disabled5').disabled=this.checked;document.getElementById('disabled6').disabled=this.checked;document.getElementById('disabled7').disabled=this.checked;document.getElementById('disabled8').disabled=this.checked;document.getElementById('disabled9').disabled=this.checked;document.getElementById('disabled10').disabled=this.checked;document.getElementById('disabled11').disabled=this.checked;document.getElementById('disabled12').disabled=this.checked;document.getElementById('disabled13').disabled=this.checked;document.getElementById('disabled14').disabled=this.checked;document.getElementById('disabled15').disabled=this.checked;document.getElementById('disabled16').disabled=this.checked;document.getElementById('disabled17').disabled=this.checked;document.getElementById('disabled18').disabled=this.checked;document.getElementById('disabled19').disabled=this.checked;document.getElementById('disabled20').disabled=this.checked;document.getElementById('disabled21').disabled=this.checked;document.getElementById('disabled22').disabled=this.checked;document.getElementById('disabled23').disabled=this.checked;document.getElementById('disabled24').disabled=this.checked;document.getElementById('disabled25').disabled=this.checked;document.getElementById('disabled26').disabled=this.checked;document.getElementById('disabled27').disabled=this.checked;document.getElementById('disabled28').disabled=this.checked;document.getElementById('disabled29').disabled=this.checked;document.getElementById('disabled30').disabled=this.checked;document.getElementById('disabled31').disabled=this.checked;document.getElementById('disabled32').disabled=this.checked"
 
-      = form_tag tutee_evaluation_path(@tutee, @evaluation), :method => :put, class: 'container-fluid' do
-        .form-group
-          %h3.font-weight-bold Tutor: #{@evaluation.tutor.first_name}
-          .form-row
+            .form-row
+              .form-group.col-md-8
+                = label :evaluation, :topics, 'What topics did you cover?'
+                = text_field :evaluation, 'topics', class: 'form-control', :placeholder => 'e.g. Tree Recusion, High-order-functions', :maxlength => 250, :required => "",
+                  :oninput => "this.setCustomValidity('')", :oninvalid => "this.setCustomValidity('Cannot be blank')", id: 'disabled1'
+            How many hours did you receive tutoring for?
+            .form-row
+              .form-group.col-md-8
+                .form-row
+                  .form-group.col-md-1
+                    = label :evaluation, :hours, '1'
+                    = radio_button :evaluation, 'hours', 1.0, id: 'disabled2'
+                  .form-group.col-md-1
+                    = label :evaluation, :hours, '1.5'
+                    = radio_button :evaluation, 'hours', 1.5, id: 'disabled3'
+                  .form-group.col-md-1
+                    = label :evaluation, :hours, '2'
+                    = radio_button :evaluation, 'hours', 2.0, id: 'disabled4'
+                  .form-group.col-md-1
+                    = label :evaluation, :hours, '2.5'
+                    = radio_button :evaluation, 'hours', 2.5, id: 'disabled5'
+                  .form-group.col-md-1
+                    = label :evaluation, :hours, '3'
+                    = radio_button :evaluation, 'hours', 3.0, id: 'disabled6'
+                  .form-group.col-md-1
+                    = label :evaluation, :hours, '3.5'
+                    = radio_button :evaluation, 'hours', 3.5, id: 'disabled7'
+                  .form-group.col-md-1
+                    = label :evaluation, :hours, '4'
+                    = radio_button :evaluation, 'hours', 4.0, id: 'disabled8'
+            .form-row
+              .form-group.col-md-8
+                = label :evaluation, :positive, 'Specifically, what did you like about how your tutor covered the material?'
+                = text_area :evaluation, 'positive', class: 'form-control', :minlength => 50, :maxlength => 6500, :required => "", :oninput => "this.setCustomValidity('')",
+                  :oninvalid => "this.setCustomValidity('Cannot be blank')", id: 'disabled9'
+            .form-row
+              .form-group.col-md-8
+                = label :evaluation, :best, "What's the best thing your tutor did?"
+                = text_area :evaluation, 'best', class: 'form-control', :minlength => 50, :maxlength => 6500, :required => "", :oninput => "this.setCustomValidity('')",
+                  :oninvalid => "this.setCustomValidity('Cannot be blank')", id: 'disabled10'
+            .form-row
+              .form-group.col-md-8
+                = label :evaluation, :feedback, "Optionally, what could your tutor constructively change or work on improving?"
+                = text_area :evaluation, 'feedback', class: 'form-control', :minlength => 50, :maxlength => 6500, :required => "", :oninput => "this.setCustomValidity('')",
+                  :oninvalid => "this.setCustomValidity('Cannot be blank')", id: 'disabled11'
             .form-group.col-md-8
-              %span Did you meet your tutor in person?
-              = label :evaluation, :took_place, 'Yes'
-              = radio_button :evaluation, 'took_place', true, id: 'radioButton2',
-              :onclick => "document.getElementById('disabled1').disabled=!this.checked;document.getElementById('disabled2').disabled=!this.checked;document.getElementById('disabled3').disabled=!this.checked;document.getElementById('disabled4').disabled=!this.checked;document.getElementById('disabled5').disabled=!this.checked;document.getElementById('disabled6').disabled=!this.checked;document.getElementById('disabled7').disabled=!this.checked;document.getElementById('disabled8').disabled=!this.checked;document.getElementById('disabled9').disabled=!this.checked;document.getElementById('disabled10').disabled=!this.checked;document.getElementById('disabled11').disabled=!this.checked;document.getElementById('disabled12').disabled=!this.checked;document.getElementById('disabled13').disabled=!this.checked;document.getElementById('disabled14').disabled=!this.checked;document.getElementById('disabled15').disabled=!this.checked;document.getElementById('disabled16').disabled=!this.checked;document.getElementById('disabled17').disabled=!this.checked;document.getElementById('disabled18').disabled=!this.checked;document.getElementById('disabled19').disabled=!this.checked;document.getElementById('disabled20').disabled=!this.checked;document.getElementById('disabled21').disabled=!this.checked;document.getElementById('disabled22').disabled=!this.checked;document.getElementById('disabled23').disabled=!this.checked;document.getElementById('disabled24').disabled=!this.checked;document.getElementById('disabled25').disabled=!this.checked;document.getElementById('disabled26').disabled=!this.checked;document.getElementById('disabled27').disabled=!this.checked;document.getElementById('disabled28').disabled=!this.checked;document.getElementById('disabled29').disabled=!this.checked;document.getElementById('disabled30').disabled=!this.checked;document.getElementById('disabled31').disabled=!this.checked;document.getElementById('disabled32').disabled=!this.checked"
-              = label :evaluation, :took_place, 'No'
-              = radio_button :evaluation, 'took_place', false, id: 'radioButton',
-              :onclick => "document.getElementById('disabled1').disabled=this.checked;document.getElementById('disabled2').disabled=this.checked;document.getElementById('disabled3').disabled=this.checked;document.getElementById('disabled4').disabled=this.checked;document.getElementById('disabled5').disabled=this.checked;document.getElementById('disabled6').disabled=this.checked;document.getElementById('disabled7').disabled=this.checked;document.getElementById('disabled8').disabled=this.checked;document.getElementById('disabled9').disabled=this.checked;document.getElementById('disabled10').disabled=this.checked;document.getElementById('disabled11').disabled=this.checked;document.getElementById('disabled12').disabled=this.checked;document.getElementById('disabled13').disabled=this.checked;document.getElementById('disabled14').disabled=this.checked;document.getElementById('disabled15').disabled=this.checked;document.getElementById('disabled16').disabled=this.checked;document.getElementById('disabled17').disabled=this.checked;document.getElementById('disabled18').disabled=this.checked;document.getElementById('disabled19').disabled=this.checked;document.getElementById('disabled20').disabled=this.checked;document.getElementById('disabled21').disabled=this.checked;document.getElementById('disabled22').disabled=this.checked;document.getElementById('disabled23').disabled=this.checked;document.getElementById('disabled24').disabled=this.checked;document.getElementById('disabled25').disabled=this.checked;document.getElementById('disabled26').disabled=this.checked;document.getElementById('disabled27').disabled=this.checked;document.getElementById('disabled28').disabled=this.checked;document.getElementById('disabled29').disabled=this.checked;document.getElementById('disabled30').disabled=this.checked;document.getElementById('disabled31').disabled=this.checked;document.getElementById('disabled32').disabled=this.checked"
-
-          .form-row
+            How knowledgeable was your tutor?
+            .form-row
+              .form-group.col-md-8
+                .form-row
+                  .form-group.col-md-2
+                    = label :evaluation, :knowledgeable, "Lacking"
+                  .form-group.col-md-1
+                    = label :evaluation, :knowledgeable, '1'
+                    = radio_button :evaluation, 'knowledgeable', 1, id: 'disabled12'
+                  .form-group.col-md-1
+                    = label :evaluation, :knowledgeable, '2'
+                    = radio_button :evaluation, 'knowledgeable', 2, id: 'disabled13'
+                  .form-group.col-md-1
+                    = label :evaluation, :knowledgeable, '3'
+                    = radio_button :evaluation, 'knowledgeable', 3, id: 'disabled14'
+                  .form-group.col-md-1
+                    = label :evaluation, :knowledgeable, '4'
+                    = radio_button :evaluation, 'knowledgeable', 4, id: 'disabled15'
+                  .form-group.col-md-1
+                    = label :evaluation, :knowledgeable, '5'
+                    = radio_button :evaluation, 'knowledgeable', 5, id: 'disabled16'
+                  .form-group.col-md-2
+                    = label :evaluation, :knowledgeable, "Superb"
             .form-group.col-md-8
-              = label :evaluation, :topics, 'What topics did you cover?'
-              = text_field :evaluation, 'topics', class: 'form-control', :placeholder => 'e.g. Tree Recusion, High-order-functions', :maxlength => 250, :required => "",
-                :oninput => "this.setCustomValidity('')", :oninvalid => "this.setCustomValidity('Cannot be blank')", id: 'disabled1'
-          How many hours did you receive tutoring for?
-          .form-row
+            How supportive or helpful was your tutor?
+            .form-row
+              .form-group.col-md-8
+                .form-row
+                  .form-group.col-md-2
+                    = label :evaluation, :helpful, "Rude"
+                  .form-group.col-md-1
+                    = label :evaluation, :helpful, '1'
+                    = radio_button :evaluation, 'helpful', 1, id: 'disabled17'
+                  .form-group.col-md-1
+                    = label :evaluation, :helpful, '2'
+                    = radio_button :evaluation, 'helpful', 2, id: 'disabled18'
+                  .form-group.col-md-1
+                    = label :evaluation, :helpful, '3'
+                    = radio_button :evaluation, 'helpful', 3, id: 'disabled19'
+                  .form-group.col-md-1
+                    = label :evaluation, :helpful, '4'
+                    = radio_button :evaluation, 'helpful', 4, id: 'disabled20'
+                  .form-group.col-md-1
+                    = label :evaluation, :helpful, '5'
+                    = radio_button :evaluation, 'helpful', 5, id: 'disabled21'
+                  .form-group.col-md-2
+                    = label :evaluation, :helpful, "Supportive"
             .form-group.col-md-8
-              .form-row
-                .form-group.col-md-1
-                  = label :evaluation, :hours, '1'
-                  = radio_button :evaluation, 'hours', 1.0, id: 'disabled2'
-                .form-group.col-md-1
-                  = label :evaluation, :hours, '1.5'
-                  = radio_button :evaluation, 'hours', 1.5, id: 'disabled3'
-                .form-group.col-md-1
-                  = label :evaluation, :hours, '2'
-                  = radio_button :evaluation, 'hours', 2.0, id: 'disabled4'
-                .form-group.col-md-1
-                  = label :evaluation, :hours, '2.5'
-                  = radio_button :evaluation, 'hours', 2.5, id: 'disabled5'
-                .form-group.col-md-1
-                  = label :evaluation, :hours, '3'
-                  = radio_button :evaluation, 'hours', 3.0, id: 'disabled6'
-                .form-group.col-md-1
-                  = label :evaluation, :hours, '3.5'
-                  = radio_button :evaluation, 'hours', 3.5, id: 'disabled7'
-                .form-group.col-md-1
-                  = label :evaluation, :hours, '4'
-                  = radio_button :evaluation, 'hours', 4.0, id: 'disabled8'
-          .form-row
+            How clear were the tutor's explanations? *
+            .form-row
+              .form-group.col-md-8
+                .form-row
+                  .form-group.col-md-2
+                    = label :evaluation, :clarity, "Vague"
+                  .form-group.col-md-1
+                    = label :evaluation, :clarity, '1'
+                    = radio_button :evaluation, 'clarity', 1, id: 'disabled22'
+                  .form-group.col-md-1
+                    = label :evaluation, :clarity, '2'
+                    = radio_button :evaluation, 'clarity', 2, id: 'disabled23'
+                  .form-group.col-md-1
+                    = label :evaluation, :clarity, '3'
+                    = radio_button :evaluation, 'clarity', 3, id: 'disabled24'
+                  .form-group.col-md-1
+                    = label :evaluation, :clarity, '4'
+                    = radio_button :evaluation, 'clarity', 4, id: 'disabled25'
+                  .form-group.col-md-1
+                    = label :evaluation, :clarity, '5'
+                    = radio_button :evaluation, 'clarity', 5, id: 'disabled26'
+                  .form-group.col-md-2
+                    = label :evaluation, :clarity, "Clear"
             .form-group.col-md-8
-              = label :evaluation, :positive, 'Specifically, what did you like about how your tutor covered the material?'
-              = text_area :evaluation, 'positive', class: 'form-control', :minlength => 50, :maxlength => 6500, :required => "", :oninput => "this.setCustomValidity('')",
-                :oninvalid => "this.setCustomValidity('Cannot be blank')", id: 'disabled9'
-          .form-row
-            .form-group.col-md-8
-              = label :evaluation, :best, "What's the best thing your tutor did?"
-              = text_area :evaluation, 'best', class: 'form-control', :minlength => 50, :maxlength => 6500, :required => "", :oninput => "this.setCustomValidity('')",
-                :oninvalid => "this.setCustomValidity('Cannot be blank')", id: 'disabled10'
-          .form-row
-            .form-group.col-md-8
-              = label :evaluation, :feedback, "Optionally, what could your tutor constructively change or work on improving?"
-              = text_area :evaluation, 'feedback', class: 'form-control', :minlength => 50, :maxlength => 6500, :required => "", :oninput => "this.setCustomValidity('')",
-                :oninvalid => "this.setCustomValidity('Cannot be blank')", id: 'disabled11'
-          .form-group.col-md-8
-          How knowledgeable was your tutor?
-          .form-row
-            .form-group.col-md-8
-              .form-row
-                .form-group.col-md-2
-                  = label :evaluation, :knowledgeable, "Lacking"
-                .form-group.col-md-1
-                  = label :evaluation, :knowledgeable, '1'
-                  = radio_button :evaluation, 'knowledgeable', 1, id: 'disabled12'
-                .form-group.col-md-1
-                  = label :evaluation, :knowledgeable, '2'
-                  = radio_button :evaluation, 'knowledgeable', 2, id: 'disabled13'
-                .form-group.col-md-1
-                  = label :evaluation, :knowledgeable, '3'
-                  = radio_button :evaluation, 'knowledgeable', 3, id: 'disabled14'
-                .form-group.col-md-1
-                  = label :evaluation, :knowledgeable, '4'
-                  = radio_button :evaluation, 'knowledgeable', 4, id: 'disabled15'
-                .form-group.col-md-1
-                  = label :evaluation, :knowledgeable, '5'
-                  = radio_button :evaluation, 'knowledgeable', 5, id: 'disabled16'
-                .form-group.col-md-2
-                  = label :evaluation, :knowledgeable, "Superb"
-          .form-group.col-md-8
-          How supportive or helpful was your tutor?
-          .form-row
-            .form-group.col-md-8
-              .form-row
-                .form-group.col-md-2
-                  = label :evaluation, :helpful, "Rude"
-                .form-group.col-md-1
-                  = label :evaluation, :helpful, '1'
-                  = radio_button :evaluation, 'helpful', 1, id: 'disabled17'
-                .form-group.col-md-1
-                  = label :evaluation, :helpful, '2'
-                  = radio_button :evaluation, 'helpful', 2, id: 'disabled18'
-                .form-group.col-md-1
-                  = label :evaluation, :helpful, '3'
-                  = radio_button :evaluation, 'helpful', 3, id: 'disabled19'
-                .form-group.col-md-1
-                  = label :evaluation, :helpful, '4'
-                  = radio_button :evaluation, 'helpful', 4, id: 'disabled20'
-                .form-group.col-md-1
-                  = label :evaluation, :helpful, '5'
-                  = radio_button :evaluation, 'helpful', 5, id: 'disabled21'
-                .form-group.col-md-2
-                  = label :evaluation, :helpful, "Supportive"
-          .form-group.col-md-8
-          How clear were the tutor's explanations? *
-          .form-row
-            .form-group.col-md-8
-              .form-row
-                .form-group.col-md-2
-                  = label :evaluation, :clarity, "Vague"
-                .form-group.col-md-1
-                  = label :evaluation, :clarity, '1'
-                  = radio_button :evaluation, 'clarity', 1, id: 'disabled22'
-                .form-group.col-md-1
-                  = label :evaluation, :clarity, '2'
-                  = radio_button :evaluation, 'clarity', 2, id: 'disabled23'
-                .form-group.col-md-1
-                  = label :evaluation, :clarity, '3'
-                  = radio_button :evaluation, 'clarity', 3, id: 'disabled24'
-                .form-group.col-md-1
-                  = label :evaluation, :clarity, '4'
-                  = radio_button :evaluation, 'clarity', 4, id: 'disabled25'
-                .form-group.col-md-1
-                  = label :evaluation, :clarity, '5'
-                  = radio_button :evaluation, 'clarity', 5, id: 'disabled26'
-                .form-group.col-md-2
-                  = label :evaluation, :clarity, "Clear"
-          .form-group.col-md-8
-          How was the pacing of the appointment? (3 means perfect speed)
-          .form-row
-            .form-group.col-md-8
-              .form-row
-                .form-group.col-md-2
-                  = label :evaluation, :pacing, "Too slow"
-                .form-group.col-md-1
-                  = label :evaluation, :pacing, '1'
-                  = radio_button :evaluation, 'pacing', 1, id: 'disabled27'
-                .form-group.col-md-1
-                  = label :evaluation, :pacing, '2'
-                  = radio_button :evaluation, 'pacing', 2, id: 'disabled28'
-                .form-group.col-md-1
-                  = label :evaluation, :pacing, '3'
-                  = radio_button :evaluation, 'pacing', 3, id: 'disabled29'
-                .form-group.col-md-1
-                  = label :evaluation, :pacing, '4'
-                  = radio_button :evaluation, 'pacing', 4, id: 'disabled30'
-                .form-group.col-md-1
-                  = label :evaluation, :pacing, '5'
-                  = radio_button :evaluation, 'pacing', 5, id: 'disabled31'
-                .form-group.col-md-2
-                  = label :evaluation, :pacing, "Too fast"
-          .form-row
-            .form-group.col-md-8
-              = label :evaluation, :final_comments, "Any comments or concerns that will be kept private from your tutor?"
-              %span.small (Visible to Instructors)
-              .form-row
-              %span.small This is for matters that you would prefer to keep private that should be raised to instructors. If it's a compliment, we suggest writing it above!
-              = text_area :evaluation, 'final_comments', class: 'form-control', :minlength => 50, :maxlength => 6500, :required => "", :oninput => "this.setCustomValidity('')",
-                :oninvalid => "this.setCustomValidity('Cannot be blank')", id: 'disabled32'
-          = hidden_field :evaluation, 'status', :value => "Complete"
-        = submit_tag 'Submit Evaluation', class: 'btn btn-primary'
+            How was the pacing of the appointment? (3 means perfect speed)
+            .form-row
+              .form-group.col-md-8
+                .form-row
+                  .form-group.col-md-2
+                    = label :evaluation, :pacing, "Too slow"
+                  .form-group.col-md-1
+                    = label :evaluation, :pacing, '1'
+                    = radio_button :evaluation, 'pacing', 1, id: 'disabled27'
+                  .form-group.col-md-1
+                    = label :evaluation, :pacing, '2'
+                    = radio_button :evaluation, 'pacing', 2, id: 'disabled28'
+                  .form-group.col-md-1
+                    = label :evaluation, :pacing, '3'
+                    = radio_button :evaluation, 'pacing', 3, id: 'disabled29'
+                  .form-group.col-md-1
+                    = label :evaluation, :pacing, '4'
+                    = radio_button :evaluation, 'pacing', 4, id: 'disabled30'
+                  .form-group.col-md-1
+                    = label :evaluation, :pacing, '5'
+                    = radio_button :evaluation, 'pacing', 5, id: 'disabled31'
+                  .form-group.col-md-2
+                    = label :evaluation, :pacing, "Too fast"
+            .form-row
+              .form-group.col-md-8
+                = label :evaluation, :final_comments, "Any comments or concerns that will be kept private from your tutor?"
+                %span.small (Visible to Instructors)
+                .form-row
+                %span.small This is for matters that you would prefer to keep private that should be raised to instructors. If it's a compliment, we suggest writing it above!
+                = text_area :evaluation, 'final_comments', class: 'form-control', :minlength => 50, :maxlength => 6500, :required => "", :oninput => "this.setCustomValidity('')",
+                  :oninvalid => "this.setCustomValidity('Cannot be blank')", id: 'disabled32'
+            = hidden_field :evaluation, 'status', :value => "Complete"
+          = submit_tag 'Submit Evaluation', class: 'btn btn-primary'
     .card-footer.small.text-muted Updated at #{ @evaluation.updated_at.in_time_zone('Pacific Time (US & Canada)').to_s + ' PST'}

--- a/coverage/index.html
+++ b/coverage/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
     <script src='./assets/0.10.2/application.js' type='text/javascript'></script>    
     <link href='./assets/0.10.2/application.css' media='screen, projection, print' rel='stylesheet' type='text/css'>
-    <link rel="shortcut icon" type="image/png" href="./assets/0.10.2/favicon_green.png" />
+    <link rel="shortcut icon" type="image/png" href="./assets/0.10.2/favicon_red.png" />
     <link rel="icon" type="image/png" href="./assets/0.10.2/favicon.png" />
   </head>
   
@@ -14,27 +14,27 @@
       <img src="./assets/0.10.2/loading.gif" alt="loading"/>
     </div>
     <div id="wrapper" style="display:none;">
-      <div class="timestamp">Generated <abbr class="timeago" title="2019-12-13T16:10:45-08:00">2019-12-13T16:10:45-08:00</abbr></div>
+      <div class="timestamp">Generated <abbr class="timeago" title="2019-12-13T18:51:30-08:00">2019-12-13T18:51:30-08:00</abbr></div>
       <ul class="group_tabs"></ul>
 
       <div id="content">
         <div class="file_list_container" id="AllFiles">
   <h2>
     <span class="group_name">All Files</span>
-    (<span class="covered_percent"><span class="green">90.1%</span></span>
+    (<span class="covered_percent"><span class="red">72.15%</span></span>
      covered at
      <span class="covered_strength">
        <span class="green">
-         6.06
+         1.28
        </span>
     </span> hits/line)
   </h2>
   <a name="AllFiles"></a>
   <div>
-    <b>62</b> files in total.
-    <b>1263</b> relevant lines. 
-    <span class="green"><b>1138</b> lines covered</span> and
-    <span class="red"><b>125</b> lines missed </span>
+    <b>55</b> files in total.
+    <b>869</b> relevant lines. 
+    <span class="green"><b>627</b> lines covered</span> and
+    <span class="red"><b>242</b> lines missed </span>
   </div>
   <table class="file_list">
     <thead>
@@ -51,117 +51,47 @@
     <tbody>
       
       <tr>
-        <td class="strong"><a href="#26463c231c580ceb270824e18bbe5ff01911c6ac" class="src_link" title="app/controllers/admins_controller.rb">app/controllers/admins_controller.rb</a></td>
-        <td class="green strong">94.4 %</td>
-        <td>210</td>
-        <td>125</td>
-        <td>118</td>
-        <td>7</td>
-        <td>5.2</td>
-      </tr>
-      
-      <tr>
-        <td class="strong"><a href="#deb1544369d2b944365327c02b6185c2c171cc09" class="src_link" title="app/controllers/application_controller.rb">app/controllers/application_controller.rb</a></td>
-        <td class="green strong">97.62 %</td>
+        <td class="strong"><a href="#236802c31882887faa7236e094e905d50cdb9bf3" class="src_link" title="app/controllers/application_controller.rb">app/controllers/application_controller.rb</a></td>
+        <td class="red strong">52.38 %</td>
         <td>69</td>
         <td>42</td>
-        <td>41</td>
-        <td>1</td>
-        <td>23.7</td>
+        <td>22</td>
+        <td>20</td>
+        <td>2.3</td>
       </tr>
       
       <tr>
-        <td class="strong"><a href="#b5fb3d324d2acbdaa2bc00feaf2285278e5aa25f" class="src_link" title="app/controllers/concerns/friendlyable.rb">app/controllers/concerns/friendlyable.rb</a></td>
+        <td class="strong"><a href="#3a784d798a7f70e1861116914d20117447cf7a1c" class="src_link" title="app/controllers/concerns/friendlyable.rb">app/controllers/concerns/friendlyable.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>16</td>
         <td>12</td>
         <td>12</td>
         <td>0</td>
-        <td>8.1</td>
+        <td>2.7</td>
       </tr>
       
       <tr>
-        <td class="strong"><a href="#2dc131ec131b9be95156a4bc77cbf698519fe74f" class="src_link" title="app/controllers/evaluations_controller.rb">app/controllers/evaluations_controller.rb</a></td>
-        <td class="green strong">91.89 %</td>
-        <td>65</td>
+        <td class="strong"><a href="#961fa774a3daca1976a1de148d9a1721e92b8179" class="src_link" title="app/controllers/evaluations_controller.rb">app/controllers/evaluations_controller.rb</a></td>
+        <td class="green strong">90.24 %</td>
+        <td>71</td>
+        <td>41</td>
         <td>37</td>
-        <td>34</td>
-        <td>3</td>
-        <td>2.1</td>
-      </tr>
-      
-      <tr>
-        <td class="strong"><a href="#ac28a37c753dec5f383ed99f7c7084fa7c6c6571" class="src_link" title="app/controllers/meetings_controller.rb">app/controllers/meetings_controller.rb</a></td>
-        <td class="yellow strong">89.74 %</td>
-        <td>62</td>
-        <td>39</td>
-        <td>35</td>
         <td>4</td>
-        <td>1.6</td>
+        <td>2.2</td>
       </tr>
       
       <tr>
-        <td class="strong"><a href="#932021a8f8c5ed62e3f0d175ddf50739ab3e035d" class="src_link" title="app/controllers/requests_controller.rb">app/controllers/requests_controller.rb</a></td>
-        <td class="red strong">50.0 %</td>
-        <td>123</td>
-        <td>78</td>
-        <td>39</td>
-        <td>39</td>
-        <td>1.2</td>
-      </tr>
-      
-      <tr>
-        <td class="strong"><a href="#6b20b2772ab1342c1afcc3a0a476461fabbfc224" class="src_link" title="app/controllers/tutees/registrations_controller.rb">app/controllers/tutees/registrations_controller.rb</a></td>
-        <td class="green strong">100.0 %</td>
-        <td>85</td>
-        <td>19</td>
-        <td>19</td>
-        <td>0</td>
+        <td class="strong"><a href="#bc31eeebacc4b76aab78d80cae2d2b30c2342bf8" class="src_link" title="app/controllers/tutees_controller.rb">app/controllers/tutees_controller.rb</a></td>
+        <td class="green strong">94.44 %</td>
+        <td>42</td>
+        <td>18</td>
+        <td>17</td>
+        <td>1</td>
         <td>4.1</td>
       </tr>
       
       <tr>
-        <td class="strong"><a href="#524a6d064aff187c5c208a80e218684f4bd44de7" class="src_link" title="app/controllers/tutees_controller.rb">app/controllers/tutees_controller.rb</a></td>
-        <td class="green strong">100.0 %</td>
-        <td>42</td>
-        <td>18</td>
-        <td>18</td>
-        <td>0</td>
-        <td>16.8</td>
-      </tr>
-      
-      <tr>
-        <td class="strong"><a href="#66ec2ac933ea6d38096d79e24af1654ce81c8ec5" class="src_link" title="app/controllers/tutors/registrations_controller.rb">app/controllers/tutors/registrations_controller.rb</a></td>
-        <td class="yellow strong">84.85 %</td>
-        <td>108</td>
-        <td>33</td>
-        <td>28</td>
-        <td>5</td>
-        <td>1.3</td>
-      </tr>
-      
-      <tr>
-        <td class="strong"><a href="#3c314adbf60036b9b6074fb2b5d3353691f4ea61" class="src_link" title="app/controllers/tutors_controller.rb">app/controllers/tutors_controller.rb</a></td>
-        <td class="red strong">76.14 %</td>
-        <td>162</td>
-        <td>88</td>
-        <td>67</td>
-        <td>21</td>
-        <td>3.3</td>
-      </tr>
-      
-      <tr>
-        <td class="strong"><a href="#f06df8ccd52345012d0ad9b304349601da1e107e" class="src_link" title="app/controllers/welcome_controller.rb">app/controllers/welcome_controller.rb</a></td>
-        <td class="red strong">31.25 %</td>
-        <td>26</td>
-        <td>16</td>
-        <td>5</td>
-        <td>11</td>
-        <td>0.3</td>
-      </tr>
-      
-      <tr>
-        <td class="strong"><a href="#5975818c13bc92d2fb951b5f1f5cc20cfd8502c9" class="src_link" title="app/helpers/admins_helper.rb">app/helpers/admins_helper.rb</a></td>
+        <td class="strong"><a href="#8174061109bdf438bd81a1431bbeb40d3abf5400" class="src_link" title="app/helpers/admins_helper.rb">app/helpers/admins_helper.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>2</td>
         <td>1</td>
@@ -171,7 +101,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#157ad42dedfca6052397934d1e6eebcae5b4dd40" class="src_link" title="app/helpers/application_helper.rb">app/helpers/application_helper.rb</a></td>
+        <td class="strong"><a href="#9bad7c699cc5787d4dd55525e67e3d066b88d4ae" class="src_link" title="app/helpers/application_helper.rb">app/helpers/application_helper.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>2</td>
         <td>1</td>
@@ -181,7 +111,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#0500870e5011744fa2d267fefc77606811ae5d3d" class="src_link" title="app/helpers/courses_helper.rb">app/helpers/courses_helper.rb</a></td>
+        <td class="strong"><a href="#fe604199a4ed8fdcbb4d51d6b67c878119cdcbbd" class="src_link" title="app/helpers/courses_helper.rb">app/helpers/courses_helper.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>2</td>
         <td>1</td>
@@ -191,7 +121,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#ee840b6e77149293e2cbb55a91b7b554bc398886" class="src_link" title="app/helpers/evaluations_helper.rb">app/helpers/evaluations_helper.rb</a></td>
+        <td class="strong"><a href="#8670736eb220f620982229f8cb452c57652ae8cf" class="src_link" title="app/helpers/evaluations_helper.rb">app/helpers/evaluations_helper.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>2</td>
         <td>1</td>
@@ -201,7 +131,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#d61ada6e6be49a1e013bf9dc24b962f23be58a7d" class="src_link" title="app/helpers/requests_helper.rb">app/helpers/requests_helper.rb</a></td>
+        <td class="strong"><a href="#146cc1182cacd0df31885e1dc2d3fd7c3cd39fff" class="src_link" title="app/helpers/requests_helper.rb">app/helpers/requests_helper.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>2</td>
         <td>1</td>
@@ -211,7 +141,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#6c2235a720ab247c02c3f5d721ba7098867caed4" class="src_link" title="app/helpers/tutees_helper.rb">app/helpers/tutees_helper.rb</a></td>
+        <td class="strong"><a href="#38e186ca1e33138aa22d4a7dd86d99372897922a" class="src_link" title="app/helpers/tutees_helper.rb">app/helpers/tutees_helper.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>2</td>
         <td>1</td>
@@ -221,7 +151,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#eada9445989d0eeb8bd69869dfa7582fe658d6f8" class="src_link" title="app/helpers/tutors_helper.rb">app/helpers/tutors_helper.rb</a></td>
+        <td class="strong"><a href="#cde4c3ca08f2c62dd99442bce16aea82b9764943" class="src_link" title="app/helpers/tutors_helper.rb">app/helpers/tutors_helper.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>2</td>
         <td>1</td>
@@ -231,7 +161,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#a2c664dea4ddef56052d946c1476a954a8770a87" class="src_link" title="app/helpers/welcome_helper.rb">app/helpers/welcome_helper.rb</a></td>
+        <td class="strong"><a href="#a96b9ddf6487918cbba8dfa313220d61343625a2" class="src_link" title="app/helpers/welcome_helper.rb">app/helpers/welcome_helper.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>2</td>
         <td>1</td>
@@ -241,17 +171,17 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#ed8eb0e3b50404db2f47123f1a5cfa375edb7c0c" class="src_link" title="app/models/admin.rb">app/models/admin.rb</a></td>
-        <td class="green strong">90.48 %</td>
+        <td class="strong"><a href="#ba36ede5cd2ce9189483bb4420c2f93c5c404e3e" class="src_link" title="app/models/admin.rb">app/models/admin.rb</a></td>
+        <td class="red strong">71.43 %</td>
         <td>43</td>
         <td>21</td>
-        <td>19</td>
-        <td>2</td>
-        <td>37.5</td>
+        <td>15</td>
+        <td>6</td>
+        <td>2.4</td>
       </tr>
       
       <tr>
-        <td class="strong"><a href="#23394b3f34a64f526639f3bf44d9b73f35adbdea" class="src_link" title="app/models/application_record.rb">app/models/application_record.rb</a></td>
+        <td class="strong"><a href="#c0758cf22796106a1de667c7204b522832d1bc88" class="src_link" title="app/models/application_record.rb">app/models/application_record.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>3</td>
         <td>2</td>
@@ -261,27 +191,27 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#6a19aefe4ad708ce3fb1f629b0687b1e78a14c61" class="src_link" title="app/models/berkeley_class.rb">app/models/berkeley_class.rb</a></td>
-        <td class="green strong">100.0 %</td>
+        <td class="strong"><a href="#caae2e678adf27d6731b59a731901b98aa388b56" class="src_link" title="app/models/berkeley_class.rb">app/models/berkeley_class.rb</a></td>
+        <td class="red strong">25.0 %</td>
         <td>21</td>
         <td>12</td>
-        <td>12</td>
-        <td>0</td>
-        <td>43.9</td>
+        <td>3</td>
+        <td>9</td>
+        <td>0.3</td>
       </tr>
       
       <tr>
-        <td class="strong"><a href="#c36bb0d35cb766151604bff00688dbba1e12b94d" class="src_link" title="app/models/course.rb">app/models/course.rb</a></td>
-        <td class="green strong">95.65 %</td>
+        <td class="strong"><a href="#0d166496ac53fb4ec86cb3c836ce22d2bbf6d338" class="src_link" title="app/models/course.rb">app/models/course.rb</a></td>
+        <td class="red strong">39.13 %</td>
         <td>53</td>
         <td>23</td>
-        <td>22</td>
-        <td>1</td>
-        <td>15.8</td>
+        <td>9</td>
+        <td>14</td>
+        <td>0.7</td>
       </tr>
       
       <tr>
-        <td class="strong"><a href="#a8dab1bd2236a88b9d4433fed7290f90a331f17c" class="src_link" title="app/models/evaluation.rb">app/models/evaluation.rb</a></td>
+        <td class="strong"><a href="#37e78311eb6a616ed6f98daf673c805fd18ac3c3" class="src_link" title="app/models/evaluation.rb">app/models/evaluation.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>20</td>
         <td>18</td>
@@ -291,17 +221,17 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#a06b8312d493c33918013966dc6e231dad452ab1" class="src_link" title="app/models/meeting.rb">app/models/meeting.rb</a></td>
-        <td class="yellow strong">88.89 %</td>
+        <td class="strong"><a href="#001038965feebf93297ee68ff8f797207e003379" class="src_link" title="app/models/meeting.rb">app/models/meeting.rb</a></td>
+        <td class="red strong">66.67 %</td>
         <td>13</td>
         <td>9</td>
-        <td>8</td>
-        <td>1</td>
-        <td>0.9</td>
+        <td>6</td>
+        <td>3</td>
+        <td>0.7</td>
       </tr>
       
       <tr>
-        <td class="strong"><a href="#d1f41e6d2ac68e6d020f2b459532d1d034f6dfb5" class="src_link" title="app/models/request.rb">app/models/request.rb</a></td>
+        <td class="strong"><a href="#7e81e6f67b1cb076d882fe7f9c9f8d7b71018753" class="src_link" title="app/models/request.rb">app/models/request.rb</a></td>
         <td class="yellow strong">87.5 %</td>
         <td>11</td>
         <td>8</td>
@@ -311,27 +241,27 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#6f1c6db58e84ab384da77bd2e24501c36decd7eb" class="src_link" title="app/models/tutee.rb">app/models/tutee.rb</a></td>
-        <td class="green strong">100.0 %</td>
+        <td class="strong"><a href="#898264f6a5e28492d330c8895b520307769a6c39" class="src_link" title="app/models/tutee.rb">app/models/tutee.rb</a></td>
+        <td class="red strong">65.0 %</td>
         <td>101</td>
         <td>60</td>
-        <td>60</td>
-        <td>0</td>
-        <td>10.2</td>
+        <td>39</td>
+        <td>21</td>
+        <td>0.8</td>
       </tr>
       
       <tr>
-        <td class="strong"><a href="#b113cbc4b89ebb17c37722a9a037e68c18659ab4" class="src_link" title="app/models/tutor.rb">app/models/tutor.rb</a></td>
-        <td class="red strong">65.63 %</td>
+        <td class="strong"><a href="#b55b68575b893af08bab0c14ccececbeaeb59f40" class="src_link" title="app/models/tutor.rb">app/models/tutor.rb</a></td>
+        <td class="red strong">46.88 %</td>
         <td>46</td>
         <td>32</td>
-        <td>21</td>
-        <td>11</td>
-        <td>1.6</td>
+        <td>15</td>
+        <td>17</td>
+        <td>0.5</td>
       </tr>
       
       <tr>
-        <td class="strong"><a href="#a026b7c087fdf4770f19267cf79398a4b36d8090" class="src_link" title="config/application.rb">config/application.rb</a></td>
+        <td class="strong"><a href="#37a71bac709a2d21c55c765a7326e89a20ae6c6d" class="src_link" title="config/application.rb">config/application.rb</a></td>
         <td class="green strong">95.24 %</td>
         <td>41</td>
         <td>21</td>
@@ -341,7 +271,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#650b852c920f608e7b28ed1c5adcff90e240c826" class="src_link" title="config/boot.rb">config/boot.rb</a></td>
+        <td class="strong"><a href="#7176a892bb03d241bded131a44ab6445892629b4" class="src_link" title="config/boot.rb">config/boot.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>4</td>
         <td>3</td>
@@ -351,7 +281,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#41b3055594e2c27828bc007edf473f6b23c3e034" class="src_link" title="config/environment.rb">config/environment.rb</a></td>
+        <td class="strong"><a href="#84725d0e425b9b8838b85a83158d6c10dfa3029c" class="src_link" title="config/environment.rb">config/environment.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>5</td>
         <td>2</td>
@@ -361,7 +291,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#45dff4e870289555106dbb04846b2f20bb5d9874" class="src_link" title="config/environments/test.rb">config/environments/test.rb</a></td>
+        <td class="strong"><a href="#58de7636cde5ebe59baff28f1fa913e60a193d76" class="src_link" title="config/environments/test.rb">config/environments/test.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>47</td>
         <td>14</td>
@@ -371,7 +301,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#7f96744ec93720b10c020f64b2ce3d10cf30d1ca" class="src_link" title="config/initializers/application_controller_renderer.rb">config/initializers/application_controller_renderer.rb</a></td>
+        <td class="strong"><a href="#4980793726624cbc48543b50736e80fc10b9c40a" class="src_link" title="config/initializers/application_controller_renderer.rb">config/initializers/application_controller_renderer.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>8</td>
         <td>0</td>
@@ -381,7 +311,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#669c57fd801262bc1eca06257db2ea76f846ce97" class="src_link" title="config/initializers/assets.rb">config/initializers/assets.rb</a></td>
+        <td class="strong"><a href="#a7dd41f082d62e0cd7f82daf179d6ac58c264495" class="src_link" title="config/initializers/assets.rb">config/initializers/assets.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>37</td>
         <td>13</td>
@@ -391,7 +321,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#86c9fe736c478c132175357e415f09057c9cb22f" class="src_link" title="config/initializers/backtrace_silencers.rb">config/initializers/backtrace_silencers.rb</a></td>
+        <td class="strong"><a href="#114998ace16fe5270a44ab8694a882baca0dca8f" class="src_link" title="config/initializers/backtrace_silencers.rb">config/initializers/backtrace_silencers.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>7</td>
         <td>0</td>
@@ -401,7 +331,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#8c23c254c5add7422077f0dffbd88bdcae4aefa3" class="src_link" title="config/initializers/content_security_policy.rb">config/initializers/content_security_policy.rb</a></td>
+        <td class="strong"><a href="#c85d6a49c112b1bdf3ca1963ccb88203b103bd9a" class="src_link" title="config/initializers/content_security_policy.rb">config/initializers/content_security_policy.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>25</td>
         <td>0</td>
@@ -411,7 +341,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#2014a789c0f1bbb9749f8254e50c595fce7756bb" class="src_link" title="config/initializers/cookies_serializer.rb">config/initializers/cookies_serializer.rb</a></td>
+        <td class="strong"><a href="#0958624c5e7ab7938e278f1cc736498db7793fbd" class="src_link" title="config/initializers/cookies_serializer.rb">config/initializers/cookies_serializer.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>5</td>
         <td>1</td>
@@ -421,7 +351,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#90d2e93d40f0a63eed06f24762e7bb6e99f60000" class="src_link" title="config/initializers/devise.rb">config/initializers/devise.rb</a></td>
+        <td class="strong"><a href="#bf5d9587b4e4271e93155f9675d2ea51ebfae3b6" class="src_link" title="config/initializers/devise.rb">config/initializers/devise.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>299</td>
         <td>15</td>
@@ -431,7 +361,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#94bb639936dc44aaf46b9363fce6284c70d06061" class="src_link" title="config/initializers/filter_parameter_logging.rb">config/initializers/filter_parameter_logging.rb</a></td>
+        <td class="strong"><a href="#d6eca56e4cdde30b8100afd713c8a8e9c0a8a389" class="src_link" title="config/initializers/filter_parameter_logging.rb">config/initializers/filter_parameter_logging.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>4</td>
         <td>1</td>
@@ -441,7 +371,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#2f1857a4f6e793e01c337219abd8b8bb221c4680" class="src_link" title="config/initializers/inflections.rb">config/initializers/inflections.rb</a></td>
+        <td class="strong"><a href="#e5fda2caad7f6fa775cfe1d4b7371d3a2cf8d6a8" class="src_link" title="config/initializers/inflections.rb">config/initializers/inflections.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>16</td>
         <td>0</td>
@@ -451,7 +381,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#12d98f3b79c7e3b406a427cb964988d8cb6c0e00" class="src_link" title="config/initializers/mime_types.rb">config/initializers/mime_types.rb</a></td>
+        <td class="strong"><a href="#53e806872a9385ef0f5f4a84502f4628c57ce7c8" class="src_link" title="config/initializers/mime_types.rb">config/initializers/mime_types.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>4</td>
         <td>0</td>
@@ -461,7 +391,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#e50fe79f6dbbbd9fe24f6096e65082fa7ea97c35" class="src_link" title="config/initializers/setup_mail.rb">config/initializers/setup_mail.rb</a></td>
+        <td class="strong"><a href="#02433b95e54fd3b29322c36cb5f27953ea897ceb" class="src_link" title="config/initializers/setup_mail.rb">config/initializers/setup_mail.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>9</td>
         <td>0</td>
@@ -471,7 +401,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#6bc89e4562d7369faf66e5bcca09f5e738432d6b" class="src_link" title="config/initializers/wrap_parameters.rb">config/initializers/wrap_parameters.rb</a></td>
+        <td class="strong"><a href="#32dba3231c8cb4f040bc0b88ba6caf27e70cbe19" class="src_link" title="config/initializers/wrap_parameters.rb">config/initializers/wrap_parameters.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>14</td>
         <td>2</td>
@@ -481,7 +411,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#f2d089850d0420171a8572ab505a14539e265f95" class="src_link" title="config/routes.rb">config/routes.rb</a></td>
+        <td class="strong"><a href="#19ebe1b2ad641329505f4a87fd70931555dced54" class="src_link" title="config/routes.rb">config/routes.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>63</td>
         <td>43</td>
@@ -491,77 +421,77 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#7e1cb99750c0361be6f1879c3cb343c5a9c9912e" class="src_link" title="features/step_definitions/tutors_steps.rb">features/step_definitions/tutors_steps.rb</a></td>
+        <td class="strong"><a href="#19988ee7766b83683bcb98f2bb3173ee45d97823" class="src_link" title="features/step_definitions/tutors_steps.rb">features/step_definitions/tutors_steps.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>11</td>
         <td>6</td>
         <td>6</td>
         <td>0</td>
-        <td>13.3</td>
+        <td>3.7</td>
       </tr>
       
       <tr>
-        <td class="strong"><a href="#cd7c47cc1a473bdb385bce3496b759966e220555" class="src_link" title="features/step_definitions/web_steps.rb">features/step_definitions/web_steps.rb</a></td>
-        <td class="green strong">91.67 %</td>
+        <td class="strong"><a href="#a47e690d440b7da1e9461757a9ab9d5261e44184" class="src_link" title="features/step_definitions/web_steps.rb">features/step_definitions/web_steps.rb</a></td>
+        <td class="red strong">62.5 %</td>
         <td>278</td>
         <td>24</td>
-        <td>22</td>
-        <td>2</td>
-        <td>3.6</td>
+        <td>15</td>
+        <td>9</td>
+        <td>1.2</td>
       </tr>
       
       <tr>
-        <td class="strong"><a href="#ee5d416283bd93619217f6c8e5c30aad4d558381" class="src_link" title="features/step_denifition/admin_steps.rb">features/step_denifition/admin_steps.rb</a></td>
-        <td class="green strong">100.0 %</td>
+        <td class="strong"><a href="#49ffee01b9c9525d5032de98cb94f619755b16f7" class="src_link" title="features/step_denifition/admin_steps.rb">features/step_denifition/admin_steps.rb</a></td>
+        <td class="red strong">25.64 %</td>
         <td>130</td>
         <td>78</td>
-        <td>78</td>
-        <td>0</td>
-        <td>4.8</td>
+        <td>20</td>
+        <td>58</td>
+        <td>0.3</td>
       </tr>
       
       <tr>
-        <td class="strong"><a href="#845ee0c5bc42d1c3e52087f03107c0a4c3a2c86b" class="src_link" title="features/step_denifition/course_steps.rb">features/step_denifition/course_steps.rb</a></td>
+        <td class="strong"><a href="#498ff13ddd1103f178b7f7a4a554f792f71e3371" class="src_link" title="features/step_denifition/course_steps.rb">features/step_denifition/course_steps.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>5</td>
         <td>3</td>
         <td>3</td>
         <td>0</td>
-        <td>21.3</td>
+        <td>3.7</td>
       </tr>
       
       <tr>
-        <td class="strong"><a href="#6861c03d7aee2fa2138b07aebb1fd8f8c6dd1d00" class="src_link" title="features/step_denifition/evaluation_steps.rb">features/step_denifition/evaluation_steps.rb</a></td>
-        <td class="green strong">93.18 %</td>
+        <td class="strong"><a href="#382582750f441300058ca7c0e9f1ca63eae02c46" class="src_link" title="features/step_denifition/evaluation_steps.rb">features/step_denifition/evaluation_steps.rb</a></td>
+        <td class="red strong">60.23 %</td>
         <td>159</td>
         <td>88</td>
-        <td>82</td>
-        <td>6</td>
-        <td>2.5</td>
+        <td>53</td>
+        <td>35</td>
+        <td>1.6</td>
       </tr>
       
       <tr>
-        <td class="strong"><a href="#50d7512d3a24f5d34532c5d80166fee4f6071a62" class="src_link" title="features/step_denifition/history_steps.rb">features/step_denifition/history_steps.rb</a></td>
-        <td class="green strong">100.0 %</td>
+        <td class="strong"><a href="#0b70e7c59ed82f487b6a8d6859fd3b630aa0df6c" class="src_link" title="features/step_denifition/history_steps.rb">features/step_denifition/history_steps.rb</a></td>
+        <td class="red strong">62.5 %</td>
         <td>16</td>
         <td>8</td>
-        <td>8</td>
-        <td>0</td>
-        <td>2.4</td>
+        <td>5</td>
+        <td>3</td>
+        <td>1.4</td>
       </tr>
       
       <tr>
-        <td class="strong"><a href="#b3ef0b9a5c6e0893341ed6c461e27acba107c545" class="src_link" title="features/step_denifition/request_steps.rb">features/step_denifition/request_steps.rb</a></td>
-        <td class="green strong">100.0 %</td>
+        <td class="strong"><a href="#4a02fb61d3c756f29c1ad2bbce5c8e7e6650d4fe" class="src_link" title="features/step_denifition/request_steps.rb">features/step_denifition/request_steps.rb</a></td>
+        <td class="red strong">50.0 %</td>
         <td>36</td>
         <td>20</td>
-        <td>20</td>
-        <td>0</td>
-        <td>3.1</td>
+        <td>10</td>
+        <td>10</td>
+        <td>0.9</td>
       </tr>
       
       <tr>
-        <td class="strong"><a href="#faf42076eee8925d4e0b1ece682ad11f6e269972" class="src_link" title="features/step_denifition/support_steps.rb">features/step_denifition/support_steps.rb</a></td>
+        <td class="strong"><a href="#bd33698cd2881071514a41b22b2027b33b57991d" class="src_link" title="features/step_denifition/support_steps.rb">features/step_denifition/support_steps.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>4</td>
         <td>0</td>
@@ -571,17 +501,17 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#783a7f10cbebe5bb3ffc8cda0874eb1c9150e7c4" class="src_link" title="features/step_denifition/tutee_steps.rb">features/step_denifition/tutee_steps.rb</a></td>
-        <td class="green strong">94.29 %</td>
+        <td class="strong"><a href="#c17eb2a1a26e070f9f395956512d418b79b907a7" class="src_link" title="features/step_denifition/tutee_steps.rb">features/step_denifition/tutee_steps.rb</a></td>
+        <td class="red strong">77.14 %</td>
         <td>74</td>
         <td>35</td>
-        <td>33</td>
-        <td>2</td>
-        <td>27.9</td>
+        <td>27</td>
+        <td>8</td>
+        <td>2.7</td>
       </tr>
       
       <tr>
-        <td class="strong"><a href="#3301fcdf4b19dc2f2bba4994feb707cea6a4149e" class="src_link" title="features/step_denifition/web_steps.rb">features/step_denifition/web_steps.rb</a></td>
+        <td class="strong"><a href="#81af62f4b2c71ac3de792322efa2fc0f9c357ab2" class="src_link" title="features/step_denifition/web_steps.rb">features/step_denifition/web_steps.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>3</td>
         <td>0</td>
@@ -591,17 +521,17 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#bd764ab7f1597e138b783e82d36acd477b97beef" class="src_link" title="features/support/paths.rb">features/support/paths.rb</a></td>
-        <td class="green strong">90.91 %</td>
+        <td class="strong"><a href="#f7050d982af38f0ab040c8011cb30da4471a0981" class="src_link" title="features/support/paths.rb">features/support/paths.rb</a></td>
+        <td class="red strong">45.45 %</td>
         <td>92</td>
         <td>33</td>
-        <td>30</td>
-        <td>3</td>
-        <td>13.0</td>
+        <td>15</td>
+        <td>18</td>
+        <td>0.9</td>
       </tr>
       
       <tr>
-        <td class="strong"><a href="#9676871e82061a50e2c6ce8bd6101458a40efb26" class="src_link" title="features/support/selectors.rb">features/support/selectors.rb</a></td>
+        <td class="strong"><a href="#e38f9e305fba98dadb325332863161f4e49306fb" class="src_link" title="features/support/selectors.rb">features/support/selectors.rb</a></td>
         <td class="red strong">42.86 %</td>
         <td>48</td>
         <td>7</td>
@@ -611,7 +541,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#b02036a06eeeddc42c1494674a7cd7793d9d632b" class="src_link" title="spec/factories/admins.rb">spec/factories/admins.rb</a></td>
+        <td class="strong"><a href="#5577c3985fc6c72ffba376bad07e50ec79e833b1" class="src_link" title="spec/factories/admins.rb">spec/factories/admins.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>7</td>
         <td>5</td>
@@ -621,7 +551,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#9a66728ef334f4807d4be60d66abe34aed2f93a8" class="src_link" title="spec/factories/core.rb">spec/factories/core.rb</a></td>
+        <td class="strong"><a href="#008fe983d7a9a54d4574b2a0c1700ce915a070c0" class="src_link" title="spec/factories/core.rb">spec/factories/core.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>22</td>
         <td>13</td>
@@ -631,7 +561,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#ed456db281e9883217ba6c8c5b36c73e67aca26b" class="src_link" title="spec/factories/courses.rb">spec/factories/courses.rb</a></td>
+        <td class="strong"><a href="#f74e125c408bdc284beebfd1324ea978665a9bae" class="src_link" title="spec/factories/courses.rb">spec/factories/courses.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>7</td>
         <td>2</td>
@@ -641,7 +571,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#ed1b6f5626733c923d46512f3a86d56daa3ca033" class="src_link" title="spec/factories/evaluations.rb">spec/factories/evaluations.rb</a></td>
+        <td class="strong"><a href="#52c160b9eeb7565b4dc4107517c545358ea652ca" class="src_link" title="spec/factories/evaluations.rb">spec/factories/evaluations.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>6</td>
         <td>4</td>
@@ -651,7 +581,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#7949e0b862cad1477cd473fa03d33ca4983881bc" class="src_link" title="spec/factories/tutees.rb">spec/factories/tutees.rb</a></td>
+        <td class="strong"><a href="#a3f953513375503138bfaac9ba873ee30ebcabb0" class="src_link" title="spec/factories/tutees.rb">spec/factories/tutees.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>141</td>
         <td>122</td>
@@ -661,7 +591,7 @@
       </tr>
       
       <tr>
-        <td class="strong"><a href="#8ecab71feacd0062ef4582655419a66a8a9e9444" class="src_link" title="spec/factories/tutors.rb">spec/factories/tutors.rb</a></td>
+        <td class="strong"><a href="#0bb29179ea4cd08f9967d768379cd187501fb7b4" class="src_link" title="spec/factories/tutors.rb">spec/factories/tutors.rb</a></td>
         <td class="green strong">100.0 %</td>
         <td>0</td>
         <td>0</td>
@@ -686,1293 +616,14 @@
     
       <div class="source_files">
       
-        <div class="source_table" id="26463c231c580ceb270824e18bbe5ff01911c6ac">
-  <div class="header">
-    <h3>app/controllers/admins_controller.rb</h3>
-    <h4><span class="green">94.4 %</span> covered</h4>
-    <div>
-      <b>125</b> relevant lines. 
-      <span class="green"><b>118</b> lines covered</span> and
-      <span class="red"><b>7</b> lines missed.</span>
-    </div>
-  </div>
-  
-  <pre>
-    <ol>
-      
-        <li class="covered" data-hits="1" data-linenumber="1">
-          <span class="hits">1</span>
-          
-          <code class="ruby">class AdminsController &lt; ApplicationController</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="2">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  layout &#39;admin_layout&#39;, :only =&gt; [:home, :update_semester, :updateCurrentSemester, :rating_tutors, :update_courses, :tutor_hours, :update_password, :update_student_priorities]</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="3">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  before_action :set_admin, except: [:landing, :destroyAdminSession]</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="4">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  before_action :check_logged_in, except: [:landing, :createAdminSession, :destroyAdminSession]</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="5">
-          
-          
-          <code class="ruby">  </code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="6">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def landing</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="7">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="8">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="9">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def tutor_hours</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="10">
-          <span class="hits">1</span>
-          
-          <code class="ruby">    @admin = Admin.find(Admin.master_admin_index)</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="11">
-          <span class="hits">1</span>
-          
-          <code class="ruby">    @current_semester = Admin.current_semester_formatted</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="12">
-          <span class="hits">1</span>
-          
-          <code class="ruby">    @tutors = Tutor.all</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="13">
-          <span class="hits">1</span>
-          
-          <code class="ruby">    @meeting = Meeting.all</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="14">
-          <span class="hits">1</span>
-          
-          <code class="ruby">    @evaluations = Evaluation.all</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="15">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="16">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="17">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def createAdminSession</code>
-        </li>
-      
-        <li class="covered" data-hits="23" data-linenumber="18">
-          <span class="hits">23</span>
-          
-          <code class="ruby">    @admin = Admin.find(Admin.master_admin_index)</code>
-        </li>
-      
-        <li class="covered" data-hits="23" data-linenumber="19">
-          <span class="hits">23</span>
-          
-          <code class="ruby">    if @admin and @admin.authenticate(params[:password])</code>
-        </li>
-      
-        <li class="covered" data-hits="22" data-linenumber="20">
-          <span class="hits">22</span>
-          
-          <code class="ruby">      session[:admin_logged_in] = true</code>
-        </li>
-      
-        <li class="covered" data-hits="22" data-linenumber="21">
-          <span class="hits">22</span>
-          
-          <code class="ruby">      redirect_to admin_home_path</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="22">
-          
-          
-          <code class="ruby">    else</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="23">
-          <span class="hits">1</span>
-          
-          <code class="ruby">      redirect_to admin_landing_path</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="24">
-          
-          
-          <code class="ruby">    end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="25">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="26">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="27">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def destroyAdminSession</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="28">
-          <span class="hits">1</span>
-          
-          <code class="ruby">    session[:admin_logged_in] = false</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="29">
-          <span class="hits">1</span>
-          
-          <code class="ruby">    redirect_to admin_landing_path</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="30">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="31">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="32">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def home</code>
-        </li>
-      
-        <li class="covered" data-hits="22" data-linenumber="33">
-          <span class="hits">22</span>
-          
-          <code class="ruby">    @semester_options = Admin.semester_possibilities</code>
-        </li>
-      
-        <li class="covered" data-hits="22" data-linenumber="34">
-          <span class="hits">22</span>
-          
-          <code class="ruby">    @current_semester = Admin.current_semester_formatted</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="35">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="36">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="37">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def update_semester</code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="38">
-          <span class="hits">6</span>
-          
-          <code class="ruby">    @semester_options = Admin.semester_possibilities</code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="39">
-          <span class="hits">6</span>
-          
-          <code class="ruby">    @current_semester = Admin.current_semester_formatted</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="40">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="41">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="42">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def updateCurrentSemester</code>
-        </li>
-      
-        <li class="covered" data-hits="3" data-linenumber="43">
-          <span class="hits">3</span>
-          
-          <code class="ruby">    if not params[:update_current_semester].nil?</code>
-        </li>
-      
-        <li class="covered" data-hits="3" data-linenumber="44">
-          <span class="hits">3</span>
-          
-          <code class="ruby">      c_sem, c_year = updateSemesterHelper(:update_current_semester)</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="45">
-          
-          
-          <code class="ruby">    end</code>
-        </li>
-      
-        <li class="covered" data-hits="3" data-linenumber="46">
-          <span class="hits">3</span>
-          
-          <code class="ruby">    if not c_sem.nil? and not c_year.nil? and Admin.validate_year(c_year)</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="47">
-          
-          
-          <code class="ruby">      # also update the courses along with updating the semester</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="48">
-          <span class="hits">2</span>
-          
-          <code class="ruby">      flash[:message] = &quot;Current semester was successfully updated.&quot;</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="49">
-          <span class="hits">2</span>
-          
-          <code class="ruby">      @old_semester_courses = Course.current_courses_formatted</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="50">
-          <span class="hits">2</span>
-          
-          <code class="ruby">      @admin.update(:current_semester =&gt; c_sem + c_year)</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="51">
-          <span class="hits">2</span>
-          
-          <code class="ruby">      Course.update_courses(@old_semester_courses) # relies on the current semester so should auto populate the new semester with the old courses</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="52">
-          
-          
-          <code class="ruby">    else</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="53">
-          <span class="hits">1</span>
-          
-          <code class="ruby">      flash[:notice] = &quot;Error updating current semester, year is likely mistyped&quot;</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="54">
-          
-          
-          <code class="ruby">    end</code>
-        </li>
-      
-        <li class="covered" data-hits="3" data-linenumber="55">
-          <span class="hits">3</span>
-          
-          <code class="ruby">    redirect_to admin_update_semester_path</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="56">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="57">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="58">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def rating_tutors</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="59">
-          <span class="hits">2</span>
-          
-          <code class="ruby">    @current_semester = Admin.current_semester_formatted</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="60">
-          <span class="hits">2</span>
-          
-          <code class="ruby">    @meetings = Meeting.all</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="61">
-          <span class="hits">2</span>
-          
-          <code class="ruby">    @ratings = calculate_ratings</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="62">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="63">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="64">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def calculate_ratings</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="65">
-          <span class="hits">2</span>
-          
-          <code class="ruby">    @tutor_ratings = Array.new</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="66">
-          <span class="hits">2</span>
-          
-          <code class="ruby">    @meetings.each do |meet|</code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="67">
-          <span class="hits">6</span>
-          
-          <code class="ruby">      tutorId = meet.tutor_id</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="68">
-          
-          
-          <code class="ruby">      #a bug fix, sometimes meetings populate more than cucumber test</code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="69">
-          <span class="hits">6</span>
-          
-          <code class="ruby">      if Tutor.find_by_id(tutorId).nil? </code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="70">
-          
-          
-          <code class="ruby">        next</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="71">
-          
-          
-          <code class="ruby">      end</code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="72">
-          <span class="hits">6</span>
-          
-          <code class="ruby">      first = Tutor.find_by_id(tutorId).first_name</code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="73">
-          <span class="hits">6</span>
-          
-          <code class="ruby">      last = Tutor.find_by_id(tutorId).last_name</code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="74">
-          <span class="hits">6</span>
-          
-          <code class="ruby">      knowledgeable, helpful, clarity, composite = _calculate_score_helper(meet)</code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="75">
-          <span class="hits">6</span>
-          
-          <code class="ruby">      found, rate = _check_existing_tutor_helper(@tutor_ratings, tutorId)</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="76">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="77">
-          <span class="hits">6</span>
-          
-          <code class="ruby">      if found</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="78">
-          <span class="hits">2</span>
-          
-          <code class="ruby">        rate[:knowledgeable] = _calculate_average_helper(rate[:knowledgeable], knowledgeable)</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="79">
-          <span class="hits">2</span>
-          
-          <code class="ruby">        rate[:helpful] = _calculate_average_helper(rate[:helpful], helpful)</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="80">
-          <span class="hits">2</span>
-          
-          <code class="ruby">        rate[:clarity] = _calculate_average_helper(rate[:clarity], clarity)</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="81">
-          <span class="hits">2</span>
-          
-          <code class="ruby">        rate[:composite] = _calculate_average_helper(rate[:composite], composite)</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="82">
-          
-          
-          <code class="ruby">      else</code>
-        </li>
-      
-        <li class="covered" data-hits="4" data-linenumber="83">
-          <span class="hits">4</span>
-          
-          <code class="ruby">        @tutor_ratings &lt;&lt; {tutorId=&gt; &quot;#{first + &quot; &quot; + last}&quot;,:knowledgeable =&gt; knowledgeable, :helpful =&gt; helpful,</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="84">
-          
-          
-          <code class="ruby">                            :clarity =&gt; clarity, :composite =&gt; composite}</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="85">
-          
-          
-          <code class="ruby">      end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="86">
-          
-          
-          <code class="ruby">    end</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="87">
-          <span class="hits">2</span>
-          
-          <code class="ruby">    @tutor_ratings</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="88">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="89">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="90">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def _check_existing_tutor_helper(tutor_rating_list, tutor_id)</code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="91">
-          <span class="hits">6</span>
-          
-          <code class="ruby">    tutor_rating_list.each do |rate|</code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="92">
-          <span class="hits">6</span>
-          
-          <code class="ruby">      if rate.include?(tutor_id)</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="93">
-          <span class="hits">2</span>
-          
-          <code class="ruby">        return true, rate</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="94">
-          
-          
-          <code class="ruby">      end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="95">
-          
-          
-          <code class="ruby">    end</code>
-        </li>
-      
-        <li class="covered" data-hits="4" data-linenumber="96">
-          <span class="hits">4</span>
-          
-          <code class="ruby">    return false, nil</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="97">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="98">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="99">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def _calculate_score_helper(meet)</code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="100">
-          <span class="hits">6</span>
-          
-          <code class="ruby">    knowledgeable_sc = Evaluation.find_by_id(meet.evaluation_id).knowledgeable</code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="101">
-          <span class="hits">6</span>
-          
-          <code class="ruby">    knowledgeable_sc = (knowledgeable_sc.nil?) ? 0.0 : knowledgeable_sc</code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="102">
-          <span class="hits">6</span>
-          
-          <code class="ruby">    helpful_sc = Evaluation.find_by_id(meet.evaluation_id).helpful</code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="103">
-          <span class="hits">6</span>
-          
-          <code class="ruby">    helpful_sc = (helpful_sc.nil?) ? 0.0 : helpful_sc</code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="104">
-          <span class="hits">6</span>
-          
-          <code class="ruby">    clarity_sc = Evaluation.find_by_id(meet.evaluation_id).clarity</code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="105">
-          <span class="hits">6</span>
-          
-          <code class="ruby">    clarity_sc = (clarity_sc.nil?) ? 0.0 : helpful_sc</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="106">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="107">
-          <span class="hits">6</span>
-          
-          <code class="ruby">    composite_sc = (knowledgeable_sc + helpful_sc + clarity_sc) / 3.0</code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="108">
-          <span class="hits">6</span>
-          
-          <code class="ruby">    return knowledgeable_sc, helpful_sc, clarity_sc, composite_sc</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="109">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="110">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="111">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def _calculate_average_helper(a, b)</code>
-        </li>
-      
-        <li class="covered" data-hits="8" data-linenumber="112">
-          <span class="hits">8</span>
-          
-          <code class="ruby">    return (a + b) / 2.0</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="113">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="114">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="115">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def updateSemesterHelper val</code>
-        </li>
-      
-        <li class="covered" data-hits="3" data-linenumber="116">
-          <span class="hits">3</span>
-          
-          <code class="ruby">    return params[val][:semester], params[val][:year]</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="117">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="118">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="119">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def update_courses</code>
-        </li>
-      
-        <li class="covered" data-hits="10" data-linenumber="120">
-          <span class="hits">10</span>
-          
-          <code class="ruby">    @current_courses = Course.current_courses_formatted</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="121">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="122">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="123">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def post_update_courses</code>
-        </li>
-      
-        <li class="covered" data-hits="4" data-linenumber="124">
-          <span class="hits">4</span>
-          
-          <code class="ruby">    if not params[:update_courses].nil? and not params[:update_courses][:courses].nil? and Course.update_courses(params[:update_courses][:courses])</code>
-        </li>
-      
-        <li class="covered" data-hits="4" data-linenumber="125">
-          <span class="hits">4</span>
-          
-          <code class="ruby">      flash[:message] = &quot;Courses updated. Any new courses should be visible below, if not try again.&quot;</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="126">
-          
-          
-          <code class="ruby">    else</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="127">
-          
-          
-          <code class="ruby">      flash[:notice] = &quot;Courses update failed. Make sure courses are properly separated (one per line).&quot;</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="128">
-          
-          
-          <code class="ruby">    end</code>
-        </li>
-      
-        <li class="covered" data-hits="4" data-linenumber="129">
-          <span class="hits">4</span>
-          
-          <code class="ruby">    redirect_to admin_update_courses_path</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="130">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="131">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="132">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def update_password</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="133">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="134">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="135">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="136">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def post_update_password</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="137">
-          <span class="hits">2</span>
-          
-          <code class="ruby">    password, confirmation_password = params[:update_password][:password], params[:update_password][:password_confirmation]</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="138">
-          <span class="hits">2</span>
-          
-          <code class="ruby">    if password == confirmation_password</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="139">
-          <span class="hits">1</span>
-          
-          <code class="ruby">      if @admin.update(:password =&gt; password)</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="140">
-          <span class="hits">1</span>
-          
-          <code class="ruby">        flash[:message] = &quot;Admin password successfully updated.&quot;</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="141">
-          
-          
-          <code class="ruby">      end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="142">
-          
-          
-          <code class="ruby">    else</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="143">
-          <span class="hits">1</span>
-          
-          <code class="ruby">      flash[:notice] = &quot;Passwords do not match&quot;</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="144">
-          
-          
-          <code class="ruby">    end</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="145">
-          <span class="hits">2</span>
-          
-          <code class="ruby">    redirect_to admin_update_password_path</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="146">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="147">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="148">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def update_student_priorities</code>
-        </li>
-      
-        <li class="covered" data-hits="16" data-linenumber="149">
-          <span class="hits">16</span>
-          
-          <code class="ruby">    @current_cs61a_scholars = Tutee.get_current_cs61a_sids_formatted</code>
-        </li>
-      
-        <li class="covered" data-hits="16" data-linenumber="150">
-          <span class="hits">16</span>
-          
-          <code class="ruby">    @current_cs61b_scholars = Tutee.get_current_cs61b_sids_formatted</code>
-        </li>
-      
-        <li class="covered" data-hits="16" data-linenumber="151">
-          <span class="hits">16</span>
-          
-          <code class="ruby">    @current_cs61c_scholars = Tutee.get_current_cs61c_sids_formatted</code>
-        </li>
-      
-        <li class="covered" data-hits="16" data-linenumber="152">
-          <span class="hits">16</span>
-          
-          <code class="ruby">    @current_cs70_scholars = Tutee.get_current_cs70_sids_formatted</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="153">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="154">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="155">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def update_student_priorities_61A</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="156">
-          <span class="hits">2</span>
-          
-          <code class="ruby">    if not params[:update_student_priorities].nil? and not params[:update_student_priorities][:CS61A].nil? and Tutee.update_cs61a_privileges(params[:update_student_priorities][:CS61A])</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="157">
-          <span class="hits">2</span>
-          
-          <code class="ruby">      flash[:message] = &quot;CS61A privileges have been updated. Any new courses should be visible below, if not try again.&quot;</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="158">
-          
-          
-          <code class="ruby">    else</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="159">
-          
-          
-          <code class="ruby">      flash[:notice] = &quot;CS61A privileges update failed. Make sure courses are properly separated (one per line).&quot;</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="160">
-          
-          
-          <code class="ruby">    end</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="161">
-          <span class="hits">2</span>
-          
-          <code class="ruby">    redirect_to admin_update_student_priorities_path</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="162">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="163">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="164">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def update_student_priorities_61B</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="165">
-          <span class="hits">2</span>
-          
-          <code class="ruby">    if not params[:update_student_priorities].nil? and not params[:update_student_priorities][:CS61B].nil? and Tutee.update_cs61b_privileges(params[:update_student_priorities][:CS61B])</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="166">
-          <span class="hits">2</span>
-          
-          <code class="ruby">      flash[:message] = &quot;CS61B privileges have been updated. Any new courses should be visible below, if not try again.&quot;</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="167">
-          
-          
-          <code class="ruby">    else</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="168">
-          
-          
-          <code class="ruby">      flash[:notice] = &quot;CS61B privileges update failed. Make sure courses are properly separated (one per line).&quot;</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="169">
-          
-          
-          <code class="ruby">    end</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="170">
-          <span class="hits">2</span>
-          
-          <code class="ruby">    puts (not params[:update_student_priorities].nil?)</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="171">
-          <span class="hits">2</span>
-          
-          <code class="ruby">    puts (not params[:update_student_priorities][:CS61B].nil?)</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="172">
-          <span class="hits">2</span>
-          
-          <code class="ruby">    redirect_to admin_update_student_priorities_path</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="173">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="174">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="175">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def update_student_priorities_61C</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="176">
-          <span class="hits">2</span>
-          
-          <code class="ruby">    if not params[:update_student_priorities].nil? and not params[:update_student_priorities][:CS61C].nil? and Tutee.update_cs61c_privileges(params[:update_student_priorities][:CS61C])</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="177">
-          <span class="hits">2</span>
-          
-          <code class="ruby">      flash[:message] = &quot;CS61C privileges have been updated. Any new courses should be visible below, if not try again.&quot;</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="178">
-          
-          
-          <code class="ruby">    else</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="179">
-          
-          
-          <code class="ruby">      flash[:notice] = &quot;CS61C privileges update failed. Make sure courses are properly separated (one per line).&quot;</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="180">
-          
-          
-          <code class="ruby">    end</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="181">
-          <span class="hits">2</span>
-          
-          <code class="ruby">    redirect_to admin_update_student_priorities_path</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="182">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="183">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="184">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def update_student_priorities_70</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="185">
-          <span class="hits">2</span>
-          
-          <code class="ruby">    if not params[:update_student_priorities].nil? and not params[:update_student_priorities][:CS70].nil? and Tutee.update_cs70_privileges(params[:update_student_priorities][:CS70])</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="186">
-          <span class="hits">2</span>
-          
-          <code class="ruby">      flash[:message] = &quot;CS70 privileges have been updated. Any new courses should be visible below, if not try again.&quot;</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="187">
-          
-          
-          <code class="ruby">    else</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="188">
-          
-          
-          <code class="ruby">      flash[:notice] = &quot;CS70 privileges update failed. Make sure courses are properly separated (one per line).&quot;</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="189">
-          
-          
-          <code class="ruby">    end</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="190">
-          <span class="hits">2</span>
-          
-          <code class="ruby">    redirect_to admin_update_student_priorities_path</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="191">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="192">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="193">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  private</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="194">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="195">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def check_logged_in</code>
-        </li>
-      
-        <li class="covered" data-hits="79" data-linenumber="196">
-          <span class="hits">79</span>
-          
-          <code class="ruby">    if session[:admin_logged_in].nil? or not session[:admin_logged_in]</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="197">
-          <span class="hits">1</span>
-          
-          <code class="ruby">      redirect_to admin_landing_path</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="198">
-          
-          
-          <code class="ruby">    end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="199">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="200">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="201">
-          
-          
-          <code class="ruby">  # Use callbacks to share common setup or constraints between actions.</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="202">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def set_admin</code>
-        </li>
-      
-        <li class="covered" data-hits="102" data-linenumber="203">
-          <span class="hits">102</span>
-          
-          <code class="ruby">    @admin = Admin.find(Admin.master_admin_index)</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="204">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="205">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="206">
-          
-          
-          <code class="ruby">  # Never trust parameters from the scary internet, only allow the white list through.</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="207">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def admin_params</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="208">
-          
-          
-          <code class="ruby">    params.require(:admin).permit(:password, :password_confirmation, :statistics_semester, :current_semester)</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="209">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="210">
-          
-          
-          <code class="ruby">end</code>
-        </li>
-      
-    </ol>
-  </pre>
-</div>
-
-      
-        <div class="source_table" id="deb1544369d2b944365327c02b6185c2c171cc09">
+        <div class="source_table" id="236802c31882887faa7236e094e905d50cdb9bf3">
   <div class="header">
     <h3>app/controllers/application_controller.rb</h3>
-    <h4><span class="green">97.62 %</span> covered</h4>
+    <h4><span class="red">52.38 %</span> covered</h4>
     <div>
       <b>42</b> relevant lines. 
-      <span class="green"><b>41</b> lines covered</span> and
-      <span class="red"><b>1</b> lines missed.</span>
+      <span class="green"><b>22</b> lines covered</span> and
+      <span class="red"><b>20</b> lines missed.</span>
     </div>
   </div>
   
@@ -2027,8 +678,8 @@
           <code class="ruby">  def configure_permitted_parameters</code>
         </li>
       
-        <li class="covered" data-hits="177" data-linenumber="9">
-          <span class="hits">177</span>
+        <li class="covered" data-hits="8" data-linenumber="9">
+          <span class="hits">8</span>
           
           <code class="ruby">    devise_parameter_sanitizer.permit(:sign_up, keys: [:first_name, :last_name, :sid, :privilege, :email, :birthdate, :gender, :ethnicity,</code>
         </li>
@@ -2039,8 +690,8 @@
           <code class="ruby">                                  :major, :dsp, :transfer, :year, :pronoun])</code>
         </li>
       
-        <li class="covered" data-hits="177" data-linenumber="11">
-          <span class="hits">177</span>
+        <li class="covered" data-hits="8" data-linenumber="11">
+          <span class="hits">8</span>
           
           <code class="ruby">    devise_parameter_sanitizer.permit(:account_update, keys: [:first_name, :last_name, :sid, :privilege, :email, :birthdate, :gender, :ethnicity,</code>
         </li>
@@ -2075,26 +726,26 @@
           <code class="ruby">  # return the path based on resource</code>
         </li>
       
-        <li class="covered" data-hits="31" data-linenumber="17">
-          <span class="hits">31</span>
+        <li class="covered" data-hits="4" data-linenumber="17">
+          <span class="hits">4</span>
           
           <code class="ruby">    puts resource</code>
         </li>
       
-        <li class="covered" data-hits="31" data-linenumber="18">
-          <span class="hits">31</span>
+        <li class="covered" data-hits="4" data-linenumber="18">
+          <span class="hits">4</span>
           
           <code class="ruby">    if resource.is_a? Tutor</code>
         </li>
       
-        <li class="covered" data-hits="4" data-linenumber="19">
-          <span class="hits">4</span>
+        <li class="missed" data-hits="0" data-linenumber="19">
+          
           
           <code class="ruby">      session[:tutor_id] = resource.id</code>
         </li>
       
-        <li class="covered" data-hits="4" data-linenumber="20">
-          <span class="hits">4</span>
+        <li class="missed" data-hits="0" data-linenumber="20">
+          
           
           <code class="ruby">      tutor_path(current_tutor)</code>
         </li>
@@ -2105,14 +756,14 @@
           <code class="ruby">    else</code>
         </li>
       
-        <li class="covered" data-hits="27" data-linenumber="22">
-          <span class="hits">27</span>
+        <li class="covered" data-hits="4" data-linenumber="22">
+          <span class="hits">4</span>
           
           <code class="ruby">      session[:tutee_id] = resource.id</code>
         </li>
       
-        <li class="covered" data-hits="27" data-linenumber="23">
-          <span class="hits">27</span>
+        <li class="covered" data-hits="4" data-linenumber="23">
+          <span class="hits">4</span>
           
           <code class="ruby">      tutee_path(current_tutee)</code>
         </li>
@@ -2141,38 +792,38 @@
           <code class="ruby">  def after_sign_out_path_for(resource)</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="28">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="28">
+          
           
           <code class="ruby">    session[:tutee_logged_in] = false</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="29">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="29">
+          
           
           <code class="ruby">    session[:tutee_id] = nil</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="30">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="30">
+          
           
           <code class="ruby">    session[:tutor_logged_in] = false</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="31">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="31">
+          
           
           <code class="ruby">    session[:tutor_id] = nil</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="32">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="32">
+          
           
           <code class="ruby">    if resource == :tutee</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="33">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="33">
+          
           
           <code class="ruby">      new_tutee_session_path</code>
         </li>
@@ -2213,38 +864,38 @@
           <code class="ruby">  def check_tutee_logged_in</code>
         </li>
       
-        <li class="covered" data-hits="64" data-linenumber="40">
-          <span class="hits">64</span>
+        <li class="covered" data-hits="8" data-linenumber="40">
+          <span class="hits">8</span>
           
           <code class="ruby">    puts &#39;CHECK TUTEE LOGGED IN &#39;</code>
         </li>
       
-        <li class="covered" data-hits="64" data-linenumber="41">
-          <span class="hits">64</span>
+        <li class="covered" data-hits="8" data-linenumber="41">
+          <span class="hits">8</span>
           
           <code class="ruby">    puts &#39;params:&#39;</code>
         </li>
       
-        <li class="covered" data-hits="64" data-linenumber="42">
-          <span class="hits">64</span>
+        <li class="covered" data-hits="8" data-linenumber="42">
+          <span class="hits">8</span>
           
           <code class="ruby">    puts params</code>
         </li>
       
-        <li class="covered" data-hits="64" data-linenumber="43">
-          <span class="hits">64</span>
+        <li class="covered" data-hits="8" data-linenumber="43">
+          <span class="hits">8</span>
           
           <code class="ruby">    tutee_id = params.has_key?(:tutee_id) ? params[:tutee_id] : -1</code>
         </li>
       
-        <li class="covered" data-hits="64" data-linenumber="44">
-          <span class="hits">64</span>
+        <li class="covered" data-hits="8" data-linenumber="44">
+          <span class="hits">8</span>
           
           <code class="ruby">    if tutee_id == -1 and params.has_key?(:id)</code>
         </li>
       
-        <li class="covered" data-hits="47" data-linenumber="45">
-          <span class="hits">47</span>
+        <li class="covered" data-hits="8" data-linenumber="45">
+          <span class="hits">8</span>
           
           <code class="ruby">      tutee_id = params[:id]</code>
         </li>
@@ -2261,20 +912,20 @@
           <code class="ruby"></code>
         </li>
       
-        <li class="covered" data-hits="64" data-linenumber="48">
-          <span class="hits">64</span>
+        <li class="covered" data-hits="8" data-linenumber="48">
+          <span class="hits">8</span>
           
           <code class="ruby">    if !(session[:tutee_id].to_i == tutee_id.to_i)</code>
         </li>
       
-        <li class="covered" data-hits="3" data-linenumber="49">
-          <span class="hits">3</span>
+        <li class="missed" data-hits="0" data-linenumber="49">
+          
           
           <code class="ruby">      sign_out :tutee</code>
         </li>
       
-        <li class="covered" data-hits="3" data-linenumber="50">
-          <span class="hits">3</span>
+        <li class="missed" data-hits="0" data-linenumber="50">
+          
           
           <code class="ruby">      redirect_to new_tutee_session_path</code>
         </li>
@@ -2303,38 +954,38 @@
           <code class="ruby">  def check_tutor_logged_in</code>
         </li>
       
-        <li class="covered" data-hits="8" data-linenumber="55">
-          <span class="hits">8</span>
+        <li class="missed" data-hits="0" data-linenumber="55">
+          
           
           <code class="ruby">    puts &#39;CHECK TUTOR LOGGED IN &#39;</code>
         </li>
       
-        <li class="covered" data-hits="8" data-linenumber="56">
-          <span class="hits">8</span>
+        <li class="missed" data-hits="0" data-linenumber="56">
+          
           
           <code class="ruby">    puts &#39;params:&#39;</code>
         </li>
       
-        <li class="covered" data-hits="8" data-linenumber="57">
-          <span class="hits">8</span>
+        <li class="missed" data-hits="0" data-linenumber="57">
+          
           
           <code class="ruby">    puts params</code>
         </li>
       
-        <li class="covered" data-hits="8" data-linenumber="58">
-          <span class="hits">8</span>
+        <li class="missed" data-hits="0" data-linenumber="58">
+          
           
           <code class="ruby">    tutor_id = params.has_key?(:tutor_id) ? params[:tutor_id] : -1</code>
         </li>
       
-        <li class="covered" data-hits="8" data-linenumber="59">
-          <span class="hits">8</span>
+        <li class="missed" data-hits="0" data-linenumber="59">
+          
           
           <code class="ruby">    if tutor_id == -1 and params.has_key?(:id)</code>
         </li>
       
-        <li class="covered" data-hits="8" data-linenumber="60">
-          <span class="hits">8</span>
+        <li class="missed" data-hits="0" data-linenumber="60">
+          
           
           <code class="ruby">      tutor_id = params[:id]</code>
         </li>
@@ -2351,20 +1002,20 @@
           <code class="ruby"></code>
         </li>
       
-        <li class="covered" data-hits="8" data-linenumber="63">
-          <span class="hits">8</span>
+        <li class="missed" data-hits="0" data-linenumber="63">
+          
           
           <code class="ruby">    if !(session[:tutor_id].to_i == tutor_id.to_i)</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="64">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="64">
+          
           
           <code class="ruby">      sign_out :tutor</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="65">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="65">
+          
           
           <code class="ruby">      redirect_to new_tutor_session_path</code>
         </li>
@@ -2398,7 +1049,7 @@
 </div>
 
       
-        <div class="source_table" id="b5fb3d324d2acbdaa2bc00feaf2285278e5aa25f">
+        <div class="source_table" id="3a784d798a7f70e1861116914d20117447cf7a1c">
   <div class="header">
     <h3>app/controllers/concerns/friendlyable.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -2460,26 +1111,26 @@
           <code class="ruby">  def set_hash_id</code>
         </li>
       
-        <li class="covered" data-hits="18" data-linenumber="9">
-          <span class="hits">18</span>
+        <li class="covered" data-hits="5" data-linenumber="9">
+          <span class="hits">5</span>
           
           <code class="ruby">    hash_id = nil</code>
         </li>
       
-        <li class="covered" data-hits="18" data-linenumber="10">
-          <span class="hits">18</span>
+        <li class="covered" data-hits="5" data-linenumber="10">
+          <span class="hits">5</span>
           
           <code class="ruby">    loop do</code>
         </li>
       
-        <li class="covered" data-hits="18" data-linenumber="11">
-          <span class="hits">18</span>
+        <li class="covered" data-hits="5" data-linenumber="11">
+          <span class="hits">5</span>
           
           <code class="ruby">      hash_id = SecureRandom.urlsafe_base64(9).gsub(/-|_/,(&#39;a&#39;..&#39;z&#39;).to_a[rand(26)])</code>
         </li>
       
-        <li class="covered" data-hits="18" data-linenumber="12">
-          <span class="hits">18</span>
+        <li class="covered" data-hits="5" data-linenumber="12">
+          <span class="hits">5</span>
           
           <code class="ruby">      break unless self.class.name.constantize.where(:hash_id =&gt; hash_id).exists?</code>
         </li>
@@ -2490,8 +1141,8 @@
           <code class="ruby">    end</code>
         </li>
       
-        <li class="covered" data-hits="18" data-linenumber="14">
-          <span class="hits">18</span>
+        <li class="covered" data-hits="5" data-linenumber="14">
+          <span class="hits">5</span>
           
           <code class="ruby">    self.hash_id = hash_id</code>
         </li>
@@ -2513,14 +1164,14 @@
 </div>
 
       
-        <div class="source_table" id="2dc131ec131b9be95156a4bc77cbf698519fe74f">
+        <div class="source_table" id="961fa774a3daca1976a1de148d9a1721e92b8179">
   <div class="header">
     <h3>app/controllers/evaluations_controller.rb</h3>
-    <h4><span class="green">91.89 %</span> covered</h4>
+    <h4><span class="green">90.24 %</span> covered</h4>
     <div>
-      <b>37</b> relevant lines. 
-      <span class="green"><b>34</b> lines covered</span> and
-      <span class="red"><b>3</b> lines missed.</span>
+      <b>41</b> relevant lines. 
+      <span class="green"><b>37</b> lines covered</span> and
+      <span class="red"><b>4</b> lines missed.</span>
     </div>
   </div>
   
@@ -2599,840 +1250,40 @@
           <code class="ruby">    @evaluation = Evaluation.friendly.find params[:id]</code>
         </li>
       
-        <li class="never" data-hits="" data-linenumber="13">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="14">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="15">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def update</code>
-        </li>
-      
-        <li class="covered" data-hits="4" data-linenumber="16">
-          <span class="hits">4</span>
-          
-          <code class="ruby">    @evaluation = Evaluation.find_by_hash_id params[:id]</code>
-        </li>
-      
-        <li class="covered" data-hits="4" data-linenumber="17">
-          <span class="hits">4</span>
-          
-          <code class="ruby">    @evaluation.update(evaluation_params)</code>
-        </li>
-      
-        <li class="covered" data-hits="4" data-linenumber="18">
-          <span class="hits">4</span>
-          
-          <code class="ruby">    puts evaluation_params</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="19">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="4" data-linenumber="20">
-          <span class="hits">4</span>
-          
-          <code class="ruby">    if params.has_key?(:tutee_id)</code>
-        </li>
-      
-        <li class="covered" data-hits="3" data-linenumber="21">
-          <span class="hits">3</span>
-          
-          <code class="ruby">      _update_params_has_key_helper(:tutee_id, @evaluation)</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="22">
-          
-          
-          <code class="ruby">    else</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="23">
-          <span class="hits">1</span>
-          
-          <code class="ruby">      _update_params_has_no_key_helper(@evaluation)</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="24">
-          
-          
-          <code class="ruby">    end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="25">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="26">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="27">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def _update_params_has_key_helper(tutee_id, eval)</code>
-        </li>
-      
-        <li class="covered" data-hits="3" data-linenumber="28">
-          <span class="hits">3</span>
-          
-          <code class="ruby">    @tutee = Tutee.find params[:tutee_id]</code>
-        </li>
-      
-        <li class="covered" data-hits="3" data-linenumber="29">
-          <span class="hits">3</span>
-          
-          <code class="ruby">    if eval.save</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="30">
-          <span class="hits">2</span>
-          
-          <code class="ruby">      flash[:message] = &#39;Evaluation form submitted sucessfully!&#39;</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="31">
-          <span class="hits">2</span>
-          
-          <code class="ruby">      redirect_to tutee_evaluations_path(@tutee)</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="32">
-          
-          
-          <code class="ruby">    else</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="33">
-          <span class="hits">1</span>
-          
-          <code class="ruby">      flash[:notice] = &#39;Evaluation form submitted unsucessfully!&#39;</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="34">
-          <span class="hits">1</span>
-          
-          <code class="ruby">      redirect_to edit_tutee_evaluation_path(@tutee)</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="35">
-          
-          
-          <code class="ruby">    end </code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="36">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="37">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="38">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def _update_params_has_no_key_helper(eval)</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="39">
-          <span class="hits">1</span>
-          
-          <code class="ruby">    if eval.save</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="40">
-          <span class="hits">1</span>
-          
-          <code class="ruby">      flash[:message] = &#39;Evaluation form submitted sucessfully!&#39;</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="41">
-          <span class="hits">1</span>
-          
-          <code class="ruby">      redirect_to evaluation_path(eval)</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="42">
-          
-          
-          <code class="ruby">    else</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="43">
-          
-          
-          <code class="ruby">      flash[:notice] = &#39;Evaluation form submitted unsucessfully!&#39;</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="44">
-          
-          
-          <code class="ruby">      redirect_to edit_evaluation_path(eval)</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="45">
-          
-          
-          <code class="ruby">    end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="46">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="47">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="48">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def index</code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="49">
-          <span class="hits">6</span>
-          
-          <code class="ruby">    @tutee = Tutee.find params[:tutee_id]</code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="50">
-          <span class="hits">6</span>
-          
-          <code class="ruby">    @evaluations = @tutee.evaluations.where(:status =&gt; &#39;Pending&#39;)</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="51">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="52">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="53">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def show</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="54">
-          
-          
-          <code class="ruby">    @evaluation = Evaluation.find_by_id params[:id]</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="55">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="56">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="57">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def public_edit</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="58">
-          <span class="hits">1</span>
-          
-          <code class="ruby">     @evaluation = Evaluation.find_by_hash_id params[:id]</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="59">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="60">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="61">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def public_show</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="62">
-          <span class="hits">1</span>
-          
-          <code class="ruby">    @evaluation = Evaluation.find_by_hash_id params[:id]</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="63">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="64">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="65">
-          
-          
-          <code class="ruby">end</code>
-        </li>
-      
-    </ol>
-  </pre>
-</div>
-
-      
-        <div class="source_table" id="ac28a37c753dec5f383ed99f7c7084fa7c6c6571">
-  <div class="header">
-    <h3>app/controllers/meetings_controller.rb</h3>
-    <h4><span class="yellow">89.74 %</span> covered</h4>
-    <div>
-      <b>39</b> relevant lines. 
-      <span class="green"><b>35</b> lines covered</span> and
-      <span class="red"><b>4</b> lines missed.</span>
-    </div>
-  </div>
-  
-  <pre>
-    <ol>
-      
-        <li class="covered" data-hits="1" data-linenumber="1">
-          <span class="hits">1</span>
-          
-          <code class="ruby">class MeetingsController &lt; ApplicationController</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="2">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  before_action :check_tutee_logged_in, :except =&gt; [:index]</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="3">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  layout &#39;tutee_layout&#39;</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="4">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="5">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def meeting_params</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="6">
-          
-          
-          <code class="ruby">    params.permit(:tutee, :tutor_id, :evaluation_id, :dates, :request_id, :tutee_id)</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="7">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="8">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="9">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def index</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="10">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="11">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="12">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def show</code>
-        </li>
-      
         <li class="covered" data-hits="4" data-linenumber="13">
           <span class="hits">4</span>
           
-          <code class="ruby">    @tutee = Tutee.find_by_id(params[:tutee_id])</code>
+          <code class="ruby">    @meeting = Meeting.where(&quot;evaluation_id = ?&quot;, @evaluation.id).first</code>
         </li>
       
         <li class="covered" data-hits="4" data-linenumber="14">
           <span class="hits">4</span>
           
-          <code class="ruby">    @req = Request.where(tutee_id: params[:tutee_id])</code>
+          <code class="ruby">    if not @meeting.nil? and not @meeting.set_time.nil?</code>
         </li>
       
-        <li class="covered" data-hits="4" data-linenumber="15">
-          <span class="hits">4</span>
+        <li class="missed" data-hits="0" data-linenumber="15">
           
-          <code class="ruby">    @meeting = Meeting.where(request_id: @req).last</code>
+          
+          <code class="ruby">      @is_eval_available = @meeting.set_time &lt; Time.now</code>
         </li>
       
         <li class="never" data-hits="" data-linenumber="16">
           
           
-          <code class="ruby"></code>
+          <code class="ruby">    else</code>
         </li>
       
         <li class="covered" data-hits="4" data-linenumber="17">
           <span class="hits">4</span>
           
-          <code class="ruby">    if not @meeting.nil?</code>
+          <code class="ruby">      @is_eval_available = true</code>
         </li>
       
-        <li class="covered" data-hits="3" data-linenumber="18">
-          <span class="hits">3</span>
-          
-          <code class="ruby">      @tutor = Tutor.find_by_id(@meeting.tutor_id)</code>
-        </li>
-      
-        <li class="covered" data-hits="3" data-linenumber="19">
-          <span class="hits">3</span>
-          
-          <code class="ruby">      @eval = Evaluation.find_by_id(@meeting.evaluation_id)</code>
-        </li>
-      
-        <li class="covered" data-hits="3" data-linenumber="20">
-          <span class="hits">3</span>
-          
-          <code class="ruby">      if @eval.status == &quot;Complete&quot;</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="21">
-          
-          
-          <code class="ruby">        @meeting = nil</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="22">
-          
-          
-          <code class="ruby">        return</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="23">
-          
-          
-          <code class="ruby">      end</code>
-        </li>
-      
-        <li class="covered" data-hits="12" data-linenumber="24">
-          <span class="hits">12</span>
-          
-          <code class="ruby">      @dates = @meeting.times.map.with_index {|time, i| [time.strftime(&quot;%A %d at %l:%M %p at &quot;) + @meeting.locations[i], i]}.to_h</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="25">
+        <li class="never" data-hits="" data-linenumber="18">
           
           
           <code class="ruby">    end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="26">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="27">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="28">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def new</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="29">
-          
-          
-          <code class="ruby">   @tutee = Tutee.find_by_id(params[:tutee_id])</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="30">
-          
-          
-          <code class="ruby">   #@dates = [Time.now]</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="31">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="32">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="33">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def edit</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="34">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="35">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="36">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def create</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="37">
-          
-          
-          <code class="ruby">    # Checks if parameters are good</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="38">
-          <span class="hits">1</span>
-          
-          <code class="ruby">    @req = Request.where(tutee_id: params[:tutee_id])</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="39">
-          <span class="hits">1</span>
-          
-          <code class="ruby">    @meeting = Meeting.where(request_id: @req).last</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="40">
-          <span class="hits">1</span>
-          
-          <code class="ruby">    @meeting.set_time = @meeting.times[params[:meeting][:set_time].to_i]</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="41">
-          <span class="hits">1</span>
-          
-          <code class="ruby">    @meeting.set_location = @meeting.locations[params[:meeting][:set_time].to_i]</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="42">
-          <span class="hits">1</span>
-          
-          <code class="ruby">    @meeting.is_scheduled = true</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="43">
-          <span class="hits">1</span>
-          
-          <code class="ruby">    @meeting.save!</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="44">
-          <span class="hits">1</span>
-          
-          <code class="ruby">    @tutee = Tutee.find_by_id(params[:tutee_id])</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="45">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="46">
-          <span class="hits">1</span>
-          
-          <code class="ruby">    redirect_to tutee_meeting_path(@tutee, 1)</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="47">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="48">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="49">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def update</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="50">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="51">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def destroy</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="52">
-          <span class="hits">1</span>
-          
-          <code class="ruby">    @req = Request.where(tutee_id: params[:tutee_id])</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="53">
-          <span class="hits">1</span>
-          
-          <code class="ruby">    @meeting = Meeting.where(request_id: @req).last</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="54">
-          <span class="hits">1</span>
-          
-          <code class="ruby">    @eval = Evaluation.find_by_id(@meeting.evaluation_id)</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="55">
-          <span class="hits">1</span>
-          
-          <code class="ruby">    @meeting.destroy!</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="56">
-          <span class="hits">1</span>
-          
-          <code class="ruby">    @eval.destroy!</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="57">
-          <span class="hits">1</span>
-          
-          <code class="ruby">    @tutee = Tutee.find_by_id(params[:tutee_id])</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="58">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="59">
-          <span class="hits">1</span>
-          
-          <code class="ruby">    flash[:message] = &quot;Your meeting was successfully cancelled. Another tutor will match with you.&quot;</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="60">
-          <span class="hits">1</span>
-          
-          <code class="ruby">    redirect_to tutee_meeting_path(@tutee, 1)</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="61">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="62">
-          
-          
-          <code class="ruby">end</code>
-        </li>
-      
-    </ol>
-  </pre>
-</div>
-
-      
-        <div class="source_table" id="932021a8f8c5ed62e3f0d175ddf50739ab3e035d">
-  <div class="header">
-    <h3>app/controllers/requests_controller.rb</h3>
-    <h4><span class="red">50.0 %</span> covered</h4>
-    <div>
-      <b>78</b> relevant lines. 
-      <span class="green"><b>39</b> lines covered</span> and
-      <span class="red"><b>39</b> lines missed.</span>
-    </div>
-  </div>
-  
-  <pre>
-    <ol>
-      
-        <li class="covered" data-hits="1" data-linenumber="1">
-          <span class="hits">1</span>
-          
-          <code class="ruby">class RequestsController &lt; ApplicationController</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="2">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  before_action :check_tutee_logged_in, :except =&gt; [:email, :index]</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="3">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  layout &#39;tutee_layout&#39;, :only =&gt; [:history, :new]                                                          </code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="4">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="5">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def request_params</code>
-        </li>
-      
-        <li class="covered" data-hits="9" data-linenumber="6">
-          <span class="hits">9</span>
-          
-          <code class="ruby">    params.require(:request).permit(:tutee_id, :course_id, :subject, :meeting_length)</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="7">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="8">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="9">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def index</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="10">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="11">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="12">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def show</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="13">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="14">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="15">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def history</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="16">
-          <span class="hits">1</span>
-          
-          <code class="ruby">    @tutee = Tutee.find_by_id(params[:tutee_id])</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="17">
-          <span class="hits">1</span>
-          
-          <code class="ruby">    @requests = Request.where(:tutee_id =&gt; params[:tutee_id])</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="18">
-          <span class="hits">1</span>
-          
-          <code class="ruby">    @evaluations = @tutee.evaluations.where(:status =&gt; &#39;Complete&#39;)</code>
         </li>
       
         <li class="never" data-hits="" data-linenumber="19">
@@ -3450,980 +1301,223 @@
         <li class="covered" data-hits="1" data-linenumber="21">
           <span class="hits">1</span>
           
-          <code class="ruby">  def new</code>
+          <code class="ruby">  def update</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="22">
-          <span class="hits">6</span>
+        <li class="covered" data-hits="4" data-linenumber="22">
+          <span class="hits">4</span>
           
-          <code class="ruby">    @tutee = Tutee.find_by_id(params[:tutee_id])</code>
+          <code class="ruby">    @evaluation = Evaluation.find_by_hash_id params[:id]</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="23">
-          <span class="hits">6</span>
+        <li class="covered" data-hits="4" data-linenumber="23">
+          <span class="hits">4</span>
           
-          <code class="ruby">    @course_array = Course.course_array</code>
+          <code class="ruby">    @evaluation.update(evaluation_params)</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="24">
-          <span class="hits">6</span>
+        <li class="covered" data-hits="4" data-linenumber="24">
+          <span class="hits">4</span>
           
-          <code class="ruby">    @meeting_time = %w(60\ minutes 90\ minutes 120\ minutes)</code>
+          <code class="ruby">    puts evaluation_params</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="25">
-          <span class="hits">6</span>
+        <li class="never" data-hits="" data-linenumber="25">
           
-          <code class="ruby">    @tutee_last_req = @tutee.requests.last</code>
+          
+          <code class="ruby"></code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="26">
-          <span class="hits">6</span>
+        <li class="covered" data-hits="4" data-linenumber="26">
+          <span class="hits">4</span>
           
-          <code class="ruby">    if not @tutee_last_req.nil?</code>
+          <code class="ruby">    if params.has_key?(:tutee_id)</code>
         </li>
       
-        <li class="missed" data-hits="0" data-linenumber="27">
+        <li class="covered" data-hits="3" data-linenumber="27">
+          <span class="hits">3</span>
           
-          
-          <code class="ruby">      @meet_for_last_req = @tutee.meetings.where(:request_id =&gt; @tutee_last_req.id).first</code>
+          <code class="ruby">      _update_params_has_key_helper(:tutee_id, @evaluation)</code>
         </li>
       
         <li class="never" data-hits="" data-linenumber="28">
           
           
-          <code class="ruby">    end</code>
+          <code class="ruby">    else</code>
         </li>
       
-        <li class="never" data-hits="" data-linenumber="29">
+        <li class="covered" data-hits="1" data-linenumber="29">
+          <span class="hits">1</span>
           
-          
-          <code class="ruby"></code>
+          <code class="ruby">      _update_params_has_no_key_helper(@evaluation)</code>
         </li>
       
         <li class="never" data-hits="" data-linenumber="30">
           
           
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="31">
-          <span class="hits">6</span>
-          
-          <code class="ruby">    if @tutee.privilege == &#39;No&#39;</code>
-        </li>
-      
-        <li class="covered" data-hits="3" data-linenumber="32">
-          <span class="hits">3</span>
-          
-          <code class="ruby">      @has_privilege = false</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="33">
-          
-          
-          <code class="ruby">    else</code>
-        </li>
-      
-        <li class="covered" data-hits="3" data-linenumber="34">
-          <span class="hits">3</span>
-          
-          <code class="ruby">      @has_privilege = true</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="35">
-          
-          
           <code class="ruby">    end</code>
         </li>
       
-        <li class="never" data-hits="" data-linenumber="36">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="37">
+        <li class="never" data-hits="" data-linenumber="31">
           
           
           <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="38">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="39">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def edit</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="40">
-          
-          
-          <code class="ruby">    # Checks if parameters are good</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="41">
-          
-          
-          <code class="ruby">    @request = Request.find_by_id(params[:id])</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="42">
-          
-          
-          <code class="ruby">    @tutee = Tutee.find_by_id(params[:tutee_id])</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="43">
-          
-          
-          <code class="ruby">    if request_params[:subject].blank?</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="44">
-          
-          
-          <code class="ruby">      flash[:notice] = &quot;Invalid request: Subject should be filled out.&quot;</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="45">
-          
-          
-          <code class="ruby">      redirect_to new_tutee_request_path(:tutee_id =&gt; params[:tutee_id])</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="46">
-          
-          
-          <code class="ruby">      return</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="47">
-          
-          
-          <code class="ruby">    else</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="48">
-          
-          
-          <code class="ruby">      @request.course_id = request_params[:course_id]</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="49">
-          
-          
-          <code class="ruby">      @request.subject = request_params[:subject]</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="50">
-          
-          
-          <code class="ruby">      if @tutee.privilege == &#39;No&#39;</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="51">
-          
-          
-          <code class="ruby">        @request.meeting_length = &#39;60 minutes&#39;</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="52">
-          
-          
-          <code class="ruby">      else</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="53">
-          
-          
-          <code class="ruby">        @request.meeting_length = request_params[:meeting_length]</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="54">
-          
-          
-          <code class="ruby">      end</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="55">
-          
-          
-          <code class="ruby">      @request.save!</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="56">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="57">
-          
-          
-          <code class="ruby">      flash[:message] = &quot;Tutoring request for class #{@request.course.name} was successfully changed!&quot;</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="58">
-          
-          
-          <code class="ruby">    end</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="59">
-          
-          
-          <code class="ruby">    redirect_to tutee_path(@tutee)</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="60">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="61">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="62">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def create</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="63">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="64">
-          
-          
-          <code class="ruby">    # Checks if parameters are good</code>
-        </li>
-      
-        <li class="covered" data-hits="4" data-linenumber="65">
-          <span class="hits">4</span>
-          
-          <code class="ruby">    if request_params[:subject].blank?</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="66">
-          <span class="hits">2</span>
-          
-          <code class="ruby">      flash[:notice] = &quot;Invalid request: Subject should be filled out.&quot;</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="67">
-          <span class="hits">2</span>
-          
-          <code class="ruby">      redirect_to new_tutee_request_path</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="68">
-          <span class="hits">2</span>
-          
-          <code class="ruby">      return</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="69">
-          
-          
-          <code class="ruby">    else</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="70">
-          <span class="hits">2</span>
-          
-          <code class="ruby">      @tutee = Tutee.find_by_id(params[:tutee_id])</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="71">
-          <span class="hits">2</span>
-          
-          <code class="ruby">      @request = Request.new(request_params)</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="72">
-          <span class="hits">2</span>
-          
-          <code class="ruby">      @request.tutee_id = @tutee.id</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="73">
-          <span class="hits">2</span>
-          
-          <code class="ruby">      @request.course_id = request_params[:course_id]</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="74">
-          <span class="hits">2</span>
-          
-          <code class="ruby">      if @tutee.privilege == &#39;No&#39;</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="75">
-          <span class="hits">1</span>
-          
-          <code class="ruby">        @request.meeting_length = &#39;60 minutes&#39;</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="76">
-          
-          
-          <code class="ruby">      else</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="77">
-          <span class="hits">1</span>
-          
-          <code class="ruby">        @request.meeting_length = request_params[:meeting_length]</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="78">
-          
-          
-          <code class="ruby">      end</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="79">
-          <span class="hits">2</span>
-          
-          <code class="ruby">      @request.save!</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="80">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="81">
-          <span class="hits">2</span>
-          
-          <code class="ruby">      flash[:message] = &quot;Tutoring request for class #{@request.course.name} was successfully created!&quot;</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="82">
-          
-          
-          <code class="ruby">    end</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="83">
-          <span class="hits">2</span>
-          
-          <code class="ruby">    redirect_to tutee_path(@tutee)</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="84">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="85">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="86">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def update</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="87">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="88">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def destroy</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="89">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="90">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def email</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="91">
-          
-          
-          <code class="ruby">    tid = params[:tutor_id]</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="92">
-          
-          
-          <code class="ruby">    sid = params[:student][:id]</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="93">
-          
-          
-          <code class="ruby">    requestid = params[:student][:requestid]</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="94">
-          
-          
-          <code class="ruby">    #tutee_id = params[:tutee_id]</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="95">
-          
-          
-          <code class="ruby">    tutor_message = &quot;&quot;</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="96">
-          
-          
-          <code class="ruby">    @eval = Evaluation.create!()</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="97">
-          
-          
-          <code class="ruby">   </code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="98">
-          
-          
-          <code class="ruby">    @times = []</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="99">
-          
-          
-          <code class="ruby">    i = 1</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="100">
-          
-          
-          <code class="ruby">    while not params[&quot;Date&quot; + i.to_s].nil?</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="101">
-          
-          
-          <code class="ruby">        @d1 = params[&quot;Date&quot; + i.to_s]</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="102">
-          
-          
-          <code class="ruby">        @temp = @d1[0..1]</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="103">
-          
-          
-          <code class="ruby">        @d1[0,1] = @d1[3,4]</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="104">
-          
-          
-          <code class="ruby">        @d1[3,5] = @temp</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="105">
-          
-          
-          <code class="ruby">        @times &lt;&lt; Time.parse(@d1 + &quot; &quot; + params[&quot;Time&quot; + i.to_s])</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="106">
-          
-          
-          <code class="ruby">        @d1 = &quot;&quot;</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="107">
-          
-          
-          <code class="ruby">        @temp = &quot;&quot;</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="108">
-          
-          
-          <code class="ruby">        i += 1</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="109">
-          
-          
-          <code class="ruby">    end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="110">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="111">
-          
-          
-          <code class="ruby">    @locs = []</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="112">
-          
-          
-          <code class="ruby">    i = 1</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="113">
-          
-          
-          <code class="ruby">    while not params[&quot;Location&quot; + i.to_s].nil?</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="114">
-          
-          
-          <code class="ruby">        @locs &lt;&lt; params[&quot;Location&quot; + i.to_s]</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="115">
-          
-          
-          <code class="ruby">        i += 1</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="116">
-          
-          
-          <code class="ruby">    end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="117">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="118">
-          
-          
-          <code class="ruby">    @meeting = Meeting.create({:tutor_id =&gt; tid.to_i, :request_id =&gt; requestid.to_i, :evaluation_id =&gt; @eval.id, :tutee_id =&gt; sid, :times =&gt; @times, :locations =&gt; @locs});</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="119">
-          
-          
-          <code class="ruby">    #TutorMailer.invite_student(tid, sid, tutor_message, requestid, @eval.id).deliver_now</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="120">
-          
-          
-          <code class="ruby">    flash[:notice] = &quot;Successfully matched!&quot;</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="121">
-          
-          
-          <code class="ruby">    redirect_to tutor_path(tid)</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="122">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="123">
-          
-          
-          <code class="ruby">end</code>
-        </li>
-      
-    </ol>
-  </pre>
-</div>
-
-      
-        <div class="source_table" id="6b20b2772ab1342c1afcc3a0a476461fabbfc224">
-  <div class="header">
-    <h3>app/controllers/tutees/registrations_controller.rb</h3>
-    <h4><span class="green">100.0 %</span> covered</h4>
-    <div>
-      <b>19</b> relevant lines. 
-      <span class="green"><b>19</b> lines covered</span> and
-      <span class="red"><b>0</b> lines missed.</span>
-    </div>
-  </div>
-  
-  <pre>
-    <ol>
-      
-        <li class="never" data-hits="" data-linenumber="1">
-          
-          
-          <code class="ruby"># frozen_string_literal: true</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="2">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="3">
-          <span class="hits">1</span>
-          
-          <code class="ruby">class Tutees::RegistrationsController &lt; Devise::RegistrationsController</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="4">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  layout &#39;tutee_layout&#39;, :only =&gt; [:show, :edit, :update]</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="5">
-          
-          
-          <code class="ruby">  # before_action :configure_sign_up_params, only: [:create]</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="6">
-          
-          
-          <code class="ruby">  # before_action :configure_account_update_params, only: [:update]</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="7">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="8">
-          
-          
-          <code class="ruby">  # GET /resource/sign_up</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="9">
-          
-          
-          <code class="ruby">  # def new</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="10">
-          
-          
-          <code class="ruby">  #   super</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="11">
-          
-          
-          <code class="ruby">  # end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="12">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="13">
-          
-          
-          <code class="ruby">  # POST /resource</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="14">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def create</code>
-        </li>
-      
-        <li class="covered" data-hits="11" data-linenumber="15">
-          <span class="hits">11</span>
-          
-          <code class="ruby">    @tutee = Tutee.new(tutee_params)</code>
-        </li>
-      
-        <li class="covered" data-hits="11" data-linenumber="16">
-          <span class="hits">11</span>
-          
-          <code class="ruby">    if @tutee.save</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="17">
-          <span class="hits">1</span>
-          
-          <code class="ruby">      respond_to do |format|</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="18">
-          <span class="hits">1</span>
-          
-          <code class="ruby">        flash[:notice] = &quot;#{@tutee.first_name} #{@tutee.last_name} was successfully created.&quot;</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="19">
-          <span class="hits">1</span>
-          
-          <code class="ruby">        puts &quot;tutee created&quot;</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="20">
-          <span class="hits">1</span>
-          
-          <code class="ruby">        puts @tutee.id</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="21">
-          <span class="hits">1</span>
-          
-          <code class="ruby">        params[:id] = @tutee.id</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="22">
-          <span class="hits">2</span>
-          
-          <code class="ruby">        format.html { redirect_to tutee_path(@tutee.id)}</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="23">
-          
-          
-          <code class="ruby">      end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="24">
-          
-          
-          <code class="ruby">    else</code>
-        </li>
-      
-        <li class="covered" data-hits="10" data-linenumber="25">
-          <span class="hits">10</span>
-          
-          <code class="ruby">      flash[:notice] = &quot;Student was not successfully created.&quot;</code>
-        </li>
-      
-        <li class="covered" data-hits="10" data-linenumber="26">
-          <span class="hits">10</span>
-          
-          <code class="ruby">      redirect_to new_tutee_session_path</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="27">
-          
-          
-          <code class="ruby">    end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="28">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="29">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="30">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def tutee_params</code>
-        </li>
-      
-        <li class="covered" data-hits="11" data-linenumber="31">
-          <span class="hits">11</span>
-          
-          <code class="ruby">    params.require(:tutee).permit(:year, :email, :first_name,</code>
         </li>
       
         <li class="never" data-hits="" data-linenumber="32">
           
           
-          <code class="ruby">      :last_name, :birthdate, :sid, :gender, :pronoun, :ethnicity, :dsp, :transfer, :major, :password, :password_confirmation, :privilege)</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="33">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="34">
-          
-          
           <code class="ruby"></code>
         </li>
       
-        <li class="never" data-hits="" data-linenumber="35">
+        <li class="covered" data-hits="1" data-linenumber="33">
+          <span class="hits">1</span>
           
-          
-          <code class="ruby">  # GET /resource/edit</code>
+          <code class="ruby">  def _update_params_has_key_helper(tutee_id, eval)</code>
         </li>
       
-        <li class="never" data-hits="" data-linenumber="36">
+        <li class="covered" data-hits="3" data-linenumber="34">
+          <span class="hits">3</span>
           
-          
-          <code class="ruby">  # def edit</code>
+          <code class="ruby">    @tutee = Tutee.find params[:tutee_id]</code>
         </li>
       
-        <li class="never" data-hits="" data-linenumber="37">
+        <li class="covered" data-hits="3" data-linenumber="35">
+          <span class="hits">3</span>
           
+          <code class="ruby">    if eval.save</code>
+        </li>
+      
+        <li class="covered" data-hits="2" data-linenumber="36">
+          <span class="hits">2</span>
           
-          <code class="ruby">  #   super</code>
+          <code class="ruby">      flash[:message] = &#39;Evaluation form submitted sucessfully!&#39;</code>
+        </li>
+      
+        <li class="covered" data-hits="2" data-linenumber="37">
+          <span class="hits">2</span>
+          
+          <code class="ruby">      redirect_to tutee_evaluations_path(@tutee)</code>
         </li>
       
         <li class="never" data-hits="" data-linenumber="38">
           
           
-          <code class="ruby">  # end</code>
+          <code class="ruby">    else</code>
         </li>
       
-        <li class="never" data-hits="" data-linenumber="39">
+        <li class="covered" data-hits="1" data-linenumber="39">
+          <span class="hits">1</span>
           
-          
-          <code class="ruby"></code>
+          <code class="ruby">      flash[:notice] = &#39;Evaluation form submitted unsucessfully!&#39;</code>
         </li>
       
-        <li class="never" data-hits="" data-linenumber="40">
+        <li class="covered" data-hits="1" data-linenumber="40">
+          <span class="hits">1</span>
           
-          
-          <code class="ruby">  # PUT /resource</code>
+          <code class="ruby">      redirect_to edit_tutee_evaluation_path(@tutee)</code>
         </li>
       
         <li class="never" data-hits="" data-linenumber="41">
           
           
-          <code class="ruby">  # def update</code>
+          <code class="ruby">    end </code>
         </li>
       
         <li class="never" data-hits="" data-linenumber="42">
           
           
-          <code class="ruby">  #   super</code>
+          <code class="ruby">  end</code>
         </li>
       
         <li class="never" data-hits="" data-linenumber="43">
           
           
-          <code class="ruby">  # end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="44">
-          
-          
           <code class="ruby"></code>
         </li>
       
-        <li class="never" data-hits="" data-linenumber="45">
+        <li class="covered" data-hits="1" data-linenumber="44">
+          <span class="hits">1</span>
           
-          
-          <code class="ruby">  # DELETE /resource</code>
+          <code class="ruby">  def _update_params_has_no_key_helper(eval)</code>
         </li>
       
-        <li class="never" data-hits="" data-linenumber="46">
+        <li class="covered" data-hits="1" data-linenumber="45">
+          <span class="hits">1</span>
           
-          
-          <code class="ruby">  # def destroy</code>
+          <code class="ruby">    if eval.save</code>
         </li>
       
-        <li class="never" data-hits="" data-linenumber="47">
+        <li class="covered" data-hits="1" data-linenumber="46">
+          <span class="hits">1</span>
           
+          <code class="ruby">      flash[:message] = &#39;Evaluation form submitted sucessfully!&#39;</code>
+        </li>
+      
+        <li class="covered" data-hits="1" data-linenumber="47">
+          <span class="hits">1</span>
           
-          <code class="ruby">  #   super</code>
+          <code class="ruby">      redirect_to evaluation_path(eval)</code>
         </li>
       
         <li class="never" data-hits="" data-linenumber="48">
           
           
-          <code class="ruby">  # end</code>
+          <code class="ruby">    else</code>
         </li>
       
-        <li class="never" data-hits="" data-linenumber="49">
+        <li class="missed" data-hits="0" data-linenumber="49">
           
           
-          <code class="ruby"></code>
+          <code class="ruby">      flash[:notice] = &#39;Evaluation form submitted unsucessfully!&#39;</code>
         </li>
       
-        <li class="never" data-hits="" data-linenumber="50">
+        <li class="missed" data-hits="0" data-linenumber="50">
           
           
-          <code class="ruby">  # GET /resource/cancel</code>
+          <code class="ruby">      redirect_to edit_evaluation_path(eval)</code>
         </li>
       
         <li class="never" data-hits="" data-linenumber="51">
           
           
-          <code class="ruby">  # Forces the session data which is usually expired after sign</code>
+          <code class="ruby">    end</code>
         </li>
       
         <li class="never" data-hits="" data-linenumber="52">
           
           
-          <code class="ruby">  # in to be expired now. This is useful if the user wants to</code>
+          <code class="ruby">  end</code>
         </li>
       
         <li class="never" data-hits="" data-linenumber="53">
           
           
-          <code class="ruby">  # cancel oauth signing in/up in the middle of the process,</code>
+          <code class="ruby"></code>
         </li>
       
-        <li class="never" data-hits="" data-linenumber="54">
+        <li class="covered" data-hits="1" data-linenumber="54">
+          <span class="hits">1</span>
           
-          
-          <code class="ruby">  # removing all OAuth session data.</code>
+          <code class="ruby">  def index</code>
         </li>
       
-        <li class="never" data-hits="" data-linenumber="55">
+        <li class="covered" data-hits="6" data-linenumber="55">
+          <span class="hits">6</span>
           
-          
-          <code class="ruby">  # def cancel</code>
+          <code class="ruby">    @tutee = Tutee.find params[:tutee_id]</code>
         </li>
       
-        <li class="never" data-hits="" data-linenumber="56">
+        <li class="covered" data-hits="6" data-linenumber="56">
+          <span class="hits">6</span>
           
-          
-          <code class="ruby">  #   super</code>
+          <code class="ruby">    @evaluations = @tutee.evaluations.where(:status =&gt; &#39;Pending&#39;)</code>
         </li>
       
         <li class="never" data-hits="" data-linenumber="57">
           
           
-          <code class="ruby">  # end</code>
+          <code class="ruby">  end</code>
         </li>
       
         <li class="never" data-hits="" data-linenumber="58">
@@ -4432,163 +1526,79 @@
           <code class="ruby"></code>
         </li>
       
-        <li class="never" data-hits="" data-linenumber="59">
+        <li class="covered" data-hits="1" data-linenumber="59">
+          <span class="hits">1</span>
           
-          
-          <code class="ruby">  # protected</code>
+          <code class="ruby">  def show</code>
         </li>
       
-        <li class="never" data-hits="" data-linenumber="60">
+        <li class="missed" data-hits="0" data-linenumber="60">
           
           
-          <code class="ruby"></code>
+          <code class="ruby">    @evaluation = Evaluation.find_by_id params[:id]</code>
         </li>
       
         <li class="never" data-hits="" data-linenumber="61">
           
           
-          <code class="ruby">  # If you have extra params to permit, append them to the sanitizer.</code>
+          <code class="ruby">  end</code>
         </li>
       
         <li class="never" data-hits="" data-linenumber="62">
           
           
-          <code class="ruby">  # def configure_sign_up_params</code>
+          <code class="ruby"></code>
         </li>
       
-        <li class="never" data-hits="" data-linenumber="63">
+        <li class="covered" data-hits="1" data-linenumber="63">
+          <span class="hits">1</span>
           
-          
-          <code class="ruby">  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])</code>
+          <code class="ruby">  def public_edit</code>
         </li>
       
-        <li class="never" data-hits="" data-linenumber="64">
+        <li class="covered" data-hits="1" data-linenumber="64">
+          <span class="hits">1</span>
           
-          
-          <code class="ruby">  # end</code>
+          <code class="ruby">     @evaluation = Evaluation.find_by_hash_id params[:id]</code>
         </li>
       
         <li class="never" data-hits="" data-linenumber="65">
           
           
-          <code class="ruby"></code>
+          <code class="ruby">  end</code>
         </li>
       
         <li class="never" data-hits="" data-linenumber="66">
           
           
-          <code class="ruby">  # If you have extra params to permit, append them to the sanitizer.</code>
+          <code class="ruby"></code>
         </li>
       
-        <li class="never" data-hits="" data-linenumber="67">
+        <li class="covered" data-hits="1" data-linenumber="67">
+          <span class="hits">1</span>
           
-          
-          <code class="ruby">  # def configure_account_update_params</code>
+          <code class="ruby">  def public_show</code>
         </li>
       
-        <li class="never" data-hits="" data-linenumber="68">
+        <li class="covered" data-hits="1" data-linenumber="68">
+          <span class="hits">1</span>
           
-          
-          <code class="ruby">  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])</code>
+          <code class="ruby">    @evaluation = Evaluation.find_by_hash_id params[:id]</code>
         </li>
       
         <li class="never" data-hits="" data-linenumber="69">
           
           
-          <code class="ruby">  # end</code>
+          <code class="ruby"></code>
         </li>
       
         <li class="never" data-hits="" data-linenumber="70">
           
           
-          <code class="ruby"></code>
+          <code class="ruby">  end</code>
         </li>
       
         <li class="never" data-hits="" data-linenumber="71">
-          
-          
-          <code class="ruby">  # # The path used after sign up.</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="72">
-          
-          
-          <code class="ruby">  # def after_sign_up_path_for(resource)</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="73">
-          
-          
-          <code class="ruby">  #   new_tutee_session_path(resource_name)</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="74">
-          
-          
-          <code class="ruby">  # end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="75">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="76">
-          
-          
-          <code class="ruby">  # The path used after sign up for inactive accounts.</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="77">
-          
-          
-          <code class="ruby">  # def after_inactive_sign_up_path_for(resource)</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="78">
-          
-          
-          <code class="ruby">  #   super(resource)</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="79">
-          
-          
-          <code class="ruby">  # end</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="80">
-          <span class="hits">1</span>
-          
-          <code class="ruby">   def after_update_path_for(resource)</code>
-        </li>
-      
-        <li class="covered" data-hits="4" data-linenumber="81">
-          <span class="hits">4</span>
-          
-          <code class="ruby">      puts &#39;resource!!&#39;</code>
-        </li>
-      
-        <li class="covered" data-hits="4" data-linenumber="82">
-          <span class="hits">4</span>
-          
-          <code class="ruby">      puts resource</code>
-        </li>
-      
-        <li class="covered" data-hits="4" data-linenumber="83">
-          <span class="hits">4</span>
-          
-          <code class="ruby">      sign_in_after_change_password? ? tutee_path(resource) : new_tutee_session_path(resource)</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="84">
-          
-          
-          <code class="ruby">    end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="85">
           
           
           <code class="ruby">end</code>
@@ -4599,14 +1609,14 @@
 </div>
 
       
-        <div class="source_table" id="524a6d064aff187c5c208a80e218684f4bd44de7">
+        <div class="source_table" id="bc31eeebacc4b76aab78d80cae2d2b30c2342bf8">
   <div class="header">
     <h3>app/controllers/tutees_controller.rb</h3>
-    <h4><span class="green">100.0 %</span> covered</h4>
+    <h4><span class="green">94.44 %</span> covered</h4>
     <div>
       <b>18</b> relevant lines. 
-      <span class="green"><b>18</b> lines covered</span> and
-      <span class="red"><b>0</b> lines missed.</span>
+      <span class="green"><b>17</b> lines covered</span> and
+      <span class="red"><b>1</b> lines missed.</span>
     </div>
   </div>
   
@@ -4703,56 +1713,56 @@
           <code class="ruby">    # puts params</code>
         </li>
       
-        <li class="covered" data-hits="44" data-linenumber="16">
-          <span class="hits">44</span>
+        <li class="covered" data-hits="8" data-linenumber="16">
+          <span class="hits">8</span>
           
           <code class="ruby">    @courses = [Course.find_by_semester(Course.current_semester)]</code>
         </li>
       
-        <li class="covered" data-hits="44" data-linenumber="17">
-          <span class="hits">44</span>
+        <li class="covered" data-hits="8" data-linenumber="17">
+          <span class="hits">8</span>
           
           <code class="ruby">    @tutee = Tutee.find_by_id(params[:id])</code>
         </li>
       
-        <li class="covered" data-hits="44" data-linenumber="18">
-          <span class="hits">44</span>
+        <li class="covered" data-hits="8" data-linenumber="18">
+          <span class="hits">8</span>
           
           <code class="ruby">    @requests = @tutee.requests.where(&#39;created_at &gt;= ?&#39;, Date.today.beginning_of_week.strftime(&quot;%Y-%m-%d&quot;))</code>
         </li>
       
-        <li class="covered" data-hits="44" data-linenumber="19">
-          <span class="hits">44</span>
+        <li class="covered" data-hits="8" data-linenumber="19">
+          <span class="hits">8</span>
           
           <code class="ruby">    @evaluations = @tutee.evaluations</code>
         </li>
       
-        <li class="covered" data-hits="44" data-linenumber="20">
-          <span class="hits">44</span>
+        <li class="covered" data-hits="8" data-linenumber="20">
+          <span class="hits">8</span>
           
           <code class="ruby">    @meeting = Meeting.where(request_id: @requests).last</code>
         </li>
       
-        <li class="covered" data-hits="44" data-linenumber="21">
-          <span class="hits">44</span>
+        <li class="covered" data-hits="8" data-linenumber="21">
+          <span class="hits">8</span>
           
           <code class="ruby">    if not @meeting.nil?</code>
         </li>
       
-        <li class="covered" data-hits="14" data-linenumber="22">
-          <span class="hits">14</span>
+        <li class="covered" data-hits="8" data-linenumber="22">
+          <span class="hits">8</span>
           
           <code class="ruby">      @lastEval = Evaluation.find_by_id( @meeting.evaluation_id)</code>
         </li>
       
-        <li class="covered" data-hits="14" data-linenumber="23">
-          <span class="hits">14</span>
+        <li class="covered" data-hits="8" data-linenumber="23">
+          <span class="hits">8</span>
           
           <code class="ruby">      if @lastEval.status == &quot;Complete&quot;</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="24">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="24">
+          
           
           <code class="ruby">        @meeting = nil</code>
         </li>
@@ -4870,1840 +1880,7 @@
 </div>
 
       
-        <div class="source_table" id="66ec2ac933ea6d38096d79e24af1654ce81c8ec5">
-  <div class="header">
-    <h3>app/controllers/tutors/registrations_controller.rb</h3>
-    <h4><span class="yellow">84.85 %</span> covered</h4>
-    <div>
-      <b>33</b> relevant lines. 
-      <span class="green"><b>28</b> lines covered</span> and
-      <span class="red"><b>5</b> lines missed.</span>
-    </div>
-  </div>
-  
-  <pre>
-    <ol>
-      
-        <li class="never" data-hits="" data-linenumber="1">
-          
-          
-          <code class="ruby"># frozen_string_literal: true</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="2">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="3">
-          <span class="hits">1</span>
-          
-          <code class="ruby">class Tutors::RegistrationsController &lt; Devise::RegistrationsController</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="4">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  layout &#39;tutor_layout&#39;, :only =&gt; [:show, :edit, :update]</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="5">
-          
-          
-          <code class="ruby">  # before_action :configure_sign_up_params, only: [:create]</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="6">
-          
-          
-          <code class="ruby">  # before_action :configure_account_update_params, only: [:update]</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="7">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="8">
-          
-          
-          <code class="ruby">  # GET /resource/sign_up</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="9">
-          
-          
-          <code class="ruby">  # def new</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="10">
-          
-          
-          <code class="ruby">  #   super</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="11">
-          
-          
-          <code class="ruby">  # end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="12">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="13">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def new</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="14">
-          <span class="hits">2</span>
-          
-          <code class="ruby">    @tutor = Tutor.new</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="15">
-          <span class="hits">2</span>
-          
-          <code class="ruby">    @berkeley_classes = BerkeleyClass.all_classes</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="16">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="17">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="18">
-          
-          
-          <code class="ruby">  # POST /resource</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="19">
-          
-          
-          <code class="ruby">  # def create</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="20">
-          
-          
-          <code class="ruby">  #   super</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="21">
-          
-          
-          <code class="ruby">  # end</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="22">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def create</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="23">
-          <span class="hits">2</span>
-          
-          <code class="ruby">    @tutor = Tutor.new(tutor_params)</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="24">
-          <span class="hits">2</span>
-          
-          <code class="ruby">    if params[:classes].blank?</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="25">
-          <span class="hits">1</span>
-          
-          <code class="ruby">      flash[:notice] = &quot;You must select at least one class.&quot;</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="26">
-          <span class="hits">1</span>
-          
-          <code class="ruby">      redirect_to new_tutor_path</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="27">
-          <span class="hits">1</span>
-          
-          <code class="ruby">      return</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="28">
-          
-          
-          <code class="ruby">    end</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="29">
-          <span class="hits">1</span>
-          
-          <code class="ruby">    @bc = BerkeleyClass.new(classes_params)</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="30">
-          <span class="hits">1</span>
-          
-          <code class="ruby">    @bc.save</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="31">
-          <span class="hits">1</span>
-          
-          <code class="ruby">    @tutor.berkeley_classes_id = @bc.id</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="32">
-          <span class="hits">1</span>
-          
-          <code class="ruby">      if @tutor.save</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="33">
-          <span class="hits">1</span>
-          
-          <code class="ruby">        flash[:notice] = &quot;#{@tutor.first_name} #{@tutor.last_name} was successfully created.&quot;</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="34">
-          <span class="hits">1</span>
-          
-          <code class="ruby">        puts &#39;tutor created&#39;</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="35">
-          <span class="hits">1</span>
-          
-          <code class="ruby">        respond_to do |format|</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="36">
-          <span class="hits">1</span>
-          
-          <code class="ruby">          flash[:notice] = &quot;#{@tutor.first_name} #{@tutor.last_name} was successfully created.&quot;</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="37">
-          <span class="hits">1</span>
-          
-          <code class="ruby">          params[:id] = @tutor.id</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="38">
-          <span class="hits">2</span>
-          
-          <code class="ruby">          format.html { redirect_to tutor_path(@tutor.id)}</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="39">
-          
-          
-          <code class="ruby">        end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="40">
-          
-          
-          <code class="ruby">      else</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="41">
-          
-          
-          <code class="ruby">        flash[:notice] = &quot;Tutor was not successfully created.&quot;</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="42">
-          
-          
-          <code class="ruby">        redirect_to new_tutor_path</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="43">
-          
-          
-          <code class="ruby">      end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="44">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="45">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="46">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def tutor_params</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="47">
-          <span class="hits">2</span>
-          
-          <code class="ruby">    params.require(:tutor).permit(:type_of_tutor, :grade_level, :email, :first_name,</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="48">
-          
-          
-          <code class="ruby">      :last_name, :birthday, :sid, :gender, :dsp?, :transfer?, :major, :password, :password_confirmation)</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="49">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="50">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="51">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def classes_params</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="52">
-          <span class="hits">1</span>
-          
-          <code class="ruby">    BerkeleyClass.all_classes.each do |current_class|</code>
-        </li>
-      
-        <li class="covered" data-hits="9" data-linenumber="53">
-          <span class="hits">9</span>
-          
-          <code class="ruby">      params[:classes][current_class] = params[:classes].has_key?(current_class) #true hash string =&gt; all hash boolean</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="54">
-          
-          
-          <code class="ruby">    end</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="55">
-          <span class="hits">1</span>
-          
-          <code class="ruby">   params.require(:classes).permit(:CS61A, :CS61B, :CS61C, :CS70, :EE16A, :EE16B, :CS88, :CS10, :DATA8) #maybe store this list as a constant</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="56">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="57">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="58">
-          
-          
-          <code class="ruby">  # GET /resource/edit</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="59">
-          
-          
-          <code class="ruby">  # def edit</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="60">
-          
-          
-          <code class="ruby">  #   super</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="61">
-          
-          
-          <code class="ruby">  # end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="62">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="63">
-          
-          
-          <code class="ruby">  # PUT /resource</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="64">
-          
-          
-          <code class="ruby">  # def update</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="65">
-          
-          
-          <code class="ruby">  #   super</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="66">
-          
-          
-          <code class="ruby">  # end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="67">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="68">
-          
-          
-          <code class="ruby">  # DELETE /resource</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="69">
-          
-          
-          <code class="ruby">  # def destroy</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="70">
-          
-          
-          <code class="ruby">  #   super</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="71">
-          
-          
-          <code class="ruby">  # end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="72">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="73">
-          
-          
-          <code class="ruby">  # GET /resource/cancel</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="74">
-          
-          
-          <code class="ruby">  # Forces the session data which is usually expired after sign</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="75">
-          
-          
-          <code class="ruby">  # in to be expired now. This is useful if the user wants to</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="76">
-          
-          
-          <code class="ruby">  # cancel oauth signing in/up in the middle of the process,</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="77">
-          
-          
-          <code class="ruby">  # removing all OAuth session data.</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="78">
-          
-          
-          <code class="ruby">  # def cancel</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="79">
-          
-          
-          <code class="ruby">  #   super</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="80">
-          
-          
-          <code class="ruby">  # end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="81">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="82">
-          
-          
-          <code class="ruby">  # protected</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="83">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="84">
-          
-          
-          <code class="ruby">  # If you have extra params to permit, append them to the sanitizer.</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="85">
-          
-          
-          <code class="ruby">  # def configure_sign_up_params</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="86">
-          
-          
-          <code class="ruby">  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="87">
-          
-          
-          <code class="ruby">  # end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="88">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="89">
-          
-          
-          <code class="ruby">  # If you have extra params to permit, append them to the sanitizer.</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="90">
-          
-          
-          <code class="ruby">  # def configure_account_update_params</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="91">
-          
-          
-          <code class="ruby">  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="92">
-          
-          
-          <code class="ruby">  # end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="93">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="94">
-          
-          
-          <code class="ruby">  # # The path used after sign up.</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="95">
-          
-          
-          <code class="ruby">  # def after_sign_up_path_for(resource)</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="96">
-          
-          
-          <code class="ruby">  #   new_tutee_session_path(resource_name)</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="97">
-          
-          
-          <code class="ruby">  # end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="98">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="99">
-          
-          
-          <code class="ruby">  # The path used after sign up for inactive accounts.</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="100">
-          
-          
-          <code class="ruby">  # def after_inactive_sign_up_path_for(resource)</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="101">
-          
-          
-          <code class="ruby">  #   super(resource)</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="102">
-          
-          
-          <code class="ruby">  # end</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="103">
-          <span class="hits">1</span>
-          
-          <code class="ruby">   def after_update_path_for(resource)</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="104">
-          
-          
-          <code class="ruby">      puts &#39;resource!!&#39;</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="105">
-          
-          
-          <code class="ruby">      puts resource</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="106">
-          
-          
-          <code class="ruby">      sign_in_after_change_password? ? tutor_path(resource) : new_tutor_session_path(resource)</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="107">
-          
-          
-          <code class="ruby">    end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="108">
-          
-          
-          <code class="ruby">end</code>
-        </li>
-      
-    </ol>
-  </pre>
-</div>
-
-      
-        <div class="source_table" id="3c314adbf60036b9b6074fb2b5d3353691f4ea61">
-  <div class="header">
-    <h3>app/controllers/tutors_controller.rb</h3>
-    <h4><span class="red">76.14 %</span> covered</h4>
-    <div>
-      <b>88</b> relevant lines. 
-      <span class="green"><b>67</b> lines covered</span> and
-      <span class="red"><b>21</b> lines missed.</span>
-    </div>
-  </div>
-  
-  <pre>
-    <ol>
-      
-        <li class="covered" data-hits="1" data-linenumber="1">
-          <span class="hits">1</span>
-          
-          <code class="ruby">require &#39;date&#39;</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="2">
-          <span class="hits">1</span>
-          
-          <code class="ruby">class TutorsController &lt; ApplicationController</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="3">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  before_action :set_tutor, only: [:show, :edit, :update, :find_students]</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="4">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  before_action :check_tutor_logged_in, only: [:index, :show]</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="5">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="6">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="7">
-          
-          
-          <code class="ruby">  # GET /tutors</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="8">
-          
-          
-          <code class="ruby">  # GET /tutors.json</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="9">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def index</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="10">
-          
-          
-          <code class="ruby">    @tutors = Tutor.all</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="11">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="12">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="13">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def find_students</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="14">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="15">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="16">
-          
-          
-          <code class="ruby">  # GET /tutors/1</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="17">
-          
-          
-          <code class="ruby">  # GET /tutors/1.json</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="18">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def show</code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="19">
-          <span class="hits">6</span>
-          
-          <code class="ruby">    @tutor = Tutor.find_by_id(params[:id])</code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="20">
-          <span class="hits">6</span>
-          
-          <code class="ruby">    @meetings = Meeting.where(&quot;set_time &gt; ? and tutor_id = ?&quot;, Time.now, params[:id])</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="21">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="22">
-          <span class="hits">6</span>
-          
-          <code class="ruby">    @test = Request.all</code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="23">
-          <span class="hits">6</span>
-          
-          <code class="ruby">    @testing = @test.map{|req| req.evaluation.nil?}</code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="24">
-          <span class="hits">6</span>
-          
-          <code class="ruby">    @abc = @testing.last</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="25">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="26">
-          <span class="hits">6</span>
-          
-          <code class="ruby">    @meeting_times = @meetings.map{|meet| meet.set_time.strftime(&quot;on %A %d at %l:%M %p&quot;)}</code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="27">
-          <span class="hits">6</span>
-          
-          <code class="ruby">    @meeting_locations = @meetings.map{|meet| meet.set_location.titleize}</code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="28">
-          <span class="hits">6</span>
-          
-          <code class="ruby">    @meeting_evals = @meetings.map{|meet| Evaluation.find_by_id(meet.evaluation_id)}</code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="29">
-          <span class="hits">6</span>
-          
-          <code class="ruby">    @meeting_evals_status = @meeting_evals.map{|eval| eval.status}</code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="30">
-          <span class="hits">6</span>
-          
-          <code class="ruby">    @meeting_evals_took_place = @meeting_evals.map{|eval| eval.took_place}</code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="31">
-          <span class="hits">6</span>
-          
-          <code class="ruby">    @meeting_tutees = @meetings.map{|meet| Tutee.find_by_id(meet.tutee_id)}</code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="32">
-          <span class="hits">6</span>
-          
-          <code class="ruby">    @meeting_emails = @meeting_tutees.map{|tutee| tutee.email}</code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="33">
-          <span class="hits">6</span>
-          
-          <code class="ruby">    @meeting_names = @meeting_tutees.map{|tutee| tutee.first_name + &quot; &quot; + tutee.last_name}</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="34">
-          
-          
-          <code class="ruby">    </code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="35">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="36">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="37">
-          
-          
-          <code class="ruby">  # GET /tutors/new</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="38">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def new</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="39">
-          
-          
-          <code class="ruby">    @tutor = Tutor.new</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="40">
-          
-          
-          <code class="ruby">    @berkeley_classes = BerkeleyClass.all_classes</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="41">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="42">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="43">
-          
-          
-          <code class="ruby">  # GET /tutors/1/edit</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="44">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def edit</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="45">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="46">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="47">
-          
-          
-          <code class="ruby">  # POST /tutors</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="48">
-          
-          
-          <code class="ruby">  # POST /tutors.json</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="49">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def create</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="50">
-          
-          
-          <code class="ruby">    @tutor = Tutor.new(tutor_params)</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="51">
-          
-          
-          <code class="ruby">    if params[:classes].blank?</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="52">
-          
-          
-          <code class="ruby">      flash[:notice] = &quot;You must select at least one class.&quot;</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="53">
-          
-          
-          <code class="ruby">      redirect_to new_tutor_path</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="54">
-          
-          
-          <code class="ruby">      return</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="55">
-          
-          
-          <code class="ruby">    end</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="56">
-          
-          
-          <code class="ruby">    @bc = BerkeleyClass.new(classes_params)</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="57">
-          
-          
-          <code class="ruby">    @bc.save</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="58">
-          
-          
-          <code class="ruby">    @tutor.berkeley_classes_id = @bc.id</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="59">
-          
-          
-          <code class="ruby">    if @tutor.save</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="60">
-          
-          
-          <code class="ruby">      # flash[:notice] = &quot;#{@tutor.first_name} #{@tutor.last_name} was successfully created.&quot;</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="61">
-          
-          
-          <code class="ruby">      respond_to do |format|</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="62">
-          
-          
-          <code class="ruby">        flash[:notice] = &quot;#{@tutor.first_name} #{@tutor.last_name} was successfully created.&quot;</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="63">
-          
-          
-          <code class="ruby">        params[:id] = @tutor.id</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="64">
-          
-          
-          <code class="ruby">        format.html { redirect_to tutor_path(@tutor.id)}</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="65">
-          
-          
-          <code class="ruby">      end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="66">
-          
-          
-          <code class="ruby">    else</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="67">
-          
-          
-          <code class="ruby">      flash[:notice] = &quot;Tutor was not successfully created.&quot;</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="68">
-          
-          
-          <code class="ruby">      redirect_to new_tutor_path</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="69">
-          
-          
-          <code class="ruby">    end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="70">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="71">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="72">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def total_hours</code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="73">
-          <span class="hits">6</span>
-          
-          <code class="ruby">    @tutor= Tutor.find(params[:id])</code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="74">
-          <span class="hits">6</span>
-          
-          <code class="ruby">    return Tutor.total_hours_helper(@tutor)</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="75">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="76">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  helper_method :total_hours</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="77">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="78">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="79">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def hours_this_week</code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="80">
-          <span class="hits">6</span>
-          
-          <code class="ruby">    @tutor= Tutor.find(params[:id])</code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="81">
-          <span class="hits">6</span>
-          
-          <code class="ruby">    return Tutor.hours_this_week_helper(@tutor)</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="82">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="83">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  helper_method :hours_this_week</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="84">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="85">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def average_hours</code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="86">
-          <span class="hits">6</span>
-          
-          <code class="ruby">    @tutor= Tutor.find(params[:id])</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="87">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="88">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="6" data-linenumber="89">
-          <span class="hits">6</span>
-          
-          <code class="ruby">    return Tutor.average_hours_helper(@tutor)</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="90">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="91">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="92">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="93">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  helper_method :average_hours</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="94">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="95">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def update</code>
-        </li>
-      
-        <li class="covered" data-hits="3" data-linenumber="96">
-          <span class="hits">3</span>
-          
-          <code class="ruby">    tutor = params[:tutor]</code>
-        </li>
-      
-        <li class="covered" data-hits="3" data-linenumber="97">
-          <span class="hits">3</span>
-          
-          <code class="ruby">    email = tutor[:email]</code>
-        </li>
-      
-        <li class="covered" data-hits="3" data-linenumber="98">
-          <span class="hits">3</span>
-          
-          <code class="ruby">    classes = params[:classes]</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="99">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="3" data-linenumber="100">
-          <span class="hits">3</span>
-          
-          <code class="ruby">    if classes.blank?</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="101">
-          <span class="hits">1</span>
-          
-          <code class="ruby">      flash[:notice] = &quot;Preferred Classes cannot be blank.&quot;</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="102">
-          <span class="hits">1</span>
-          
-          <code class="ruby">      redirect_to edit_tutor_path(@tutor.id)</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="103">
-          <span class="hits">1</span>
-          
-          <code class="ruby">      return</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="104">
-          
-          
-          <code class="ruby">    end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="105">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="106">
-          <span class="hits">2</span>
-          
-          <code class="ruby">    respond_to do |format|</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="107">
-          <span class="hits">2</span>
-          
-          <code class="ruby">      if @tutor.update(tutor_params) &amp;&amp; @class_obj.update(classes_params)</code>
-        </li>
-      
-        <li class="covered" data-hits="4" data-linenumber="108">
-          <span class="hits">4</span>
-          
-          <code class="ruby">        format.html { redirect_to @tutor, notice: &#39;Tutor was successfully updated.&#39; }</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="109">
-          <span class="hits">2</span>
-          
-          <code class="ruby">        format.json { render :show, status: :ok, location: @tutor }</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="110">
-          
-          
-          <code class="ruby">      else</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="111">
-          
-          
-          <code class="ruby">        format.html { render :edit }</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="112">
-          
-          
-          <code class="ruby">        format.json { render json: @tutor.errors, status: :unprocessable_entity }</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="113">
-          
-          
-          <code class="ruby">      end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="114">
-          
-          
-          <code class="ruby">    end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="115">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="116">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="117">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def destroy</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="118">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="119">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="120">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="121">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def requests</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="122">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="123">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="124">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="125">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  private</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="126">
-          
-          
-          <code class="ruby">    # Use callbacks to share common setup or constraints between actions.</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="127">
-          <span class="hits">1</span>
-          
-          <code class="ruby">    VALID_EMAIL_REGEX = /A[\w+\-.]+@berkeley.edu/</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="128">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="129">
-          <span class="hits">1</span>
-          
-          <code class="ruby">    def set_tutor</code>
-        </li>
-      
-        <li class="covered" data-hits="17" data-linenumber="130">
-          <span class="hits">17</span>
-          
-          <code class="ruby">      if params[:id] == &quot;sign_out&quot; || params[:id] == &quot;new&quot; </code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="131">
-          <span class="hits">1</span>
-          
-          <code class="ruby">        redirect_to new_tutor_session_path</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="132">
-          
-          
-          <code class="ruby">      else</code>
-        </li>
-      
-        <li class="covered" data-hits="16" data-linenumber="133">
-          <span class="hits">16</span>
-          
-          <code class="ruby">        if params[:id]</code>
-        </li>
-      
-        <li class="covered" data-hits="15" data-linenumber="134">
-          <span class="hits">15</span>
-          
-          <code class="ruby">          @tutor = Tutor.find(params[:id])</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="135">
-          
-          
-          <code class="ruby">        else</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="136">
-          <span class="hits">1</span>
-          
-          <code class="ruby">          @tutor = Tutor.find(params[:tutor_id])</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="137">
-          
-          
-          <code class="ruby">        end</code>
-        </li>
-      
-        <li class="covered" data-hits="16" data-linenumber="138">
-          <span class="hits">16</span>
-          
-          <code class="ruby">        @all_classes = BerkeleyClass.all_classes</code>
-        </li>
-      
-        <li class="covered" data-hits="16" data-linenumber="139">
-          <span class="hits">16</span>
-          
-          <code class="ruby">        @class_obj = BerkeleyClass.find(@tutor.berkeley_classes_id)</code>
-        </li>
-      
-        <li class="covered" data-hits="16" data-linenumber="140">
-          <span class="hits">16</span>
-          
-          <code class="ruby">        @true_classes = @class_obj.true_classes</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="141">
-          
-          
-          <code class="ruby">      end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="142">
-          
-          
-          <code class="ruby">    end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="143">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="144">
-          <span class="hits">1</span>
-          
-          <code class="ruby">    def validate_email (email)</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="145">
-          
-          
-          <code class="ruby">      /\A[\w+\-.]+@berkeley.edu/.match(email)</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="146">
-          
-          
-          <code class="ruby">    end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="147">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="148">
-          
-          
-          <code class="ruby">    # Never trust parameters from the scary internet, only allow the white list through.</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="149">
-          <span class="hits">1</span>
-          
-          <code class="ruby">    def tutor_params</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="150">
-          <span class="hits">2</span>
-          
-          <code class="ruby">      params.require(:tutor).permit(:type_of_tutor, :grade_level, :email, :first_name,</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="151">
-          
-          
-          <code class="ruby">        :last_name, :birthday, :sid, :gender, :dsp?, :transfer?, :major)</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="152">
-          
-          
-          <code class="ruby">    end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="153">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="154">
-          <span class="hits">1</span>
-          
-          <code class="ruby">    def classes_params</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="155">
-          <span class="hits">2</span>
-          
-          <code class="ruby">      BerkeleyClass.all_classes.each do |current_class|</code>
-        </li>
-      
-        <li class="covered" data-hits="18" data-linenumber="156">
-          <span class="hits">18</span>
-          
-          <code class="ruby">        params[:classes][current_class] = params[:classes].has_key?(current_class) #true hash string =&gt; all hash boolean</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="157">
-          
-          
-          <code class="ruby">      end</code>
-        </li>
-      
-        <li class="covered" data-hits="2" data-linenumber="158">
-          <span class="hits">2</span>
-          
-          <code class="ruby">     params.require(:classes).permit(:CS61A, :CS61B, :CS61C, :CS70, :EE16A, :EE16B, :CS88, :CS10, :DATA8) #maybe store this list as a constant</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="159">
-          
-          
-          <code class="ruby">    end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="160">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="161">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="162">
-          
-          
-          <code class="ruby">end</code>
-        </li>
-      
-    </ol>
-  </pre>
-</div>
-
-      
-        <div class="source_table" id="f06df8ccd52345012d0ad9b304349601da1e107e">
-  <div class="header">
-    <h3>app/controllers/welcome_controller.rb</h3>
-    <h4><span class="red">31.25 %</span> covered</h4>
-    <div>
-      <b>16</b> relevant lines. 
-      <span class="green"><b>5</b> lines covered</span> and
-      <span class="red"><b>11</b> lines missed.</span>
-    </div>
-  </div>
-  
-  <pre>
-    <ol>
-      
-        <li class="covered" data-hits="1" data-linenumber="1">
-          <span class="hits">1</span>
-          
-          <code class="ruby">class WelcomeController &lt; ApplicationController</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="2">
-          <span class="hits">1</span>
-          
-          <code class="ruby">	skip_before_action :verify_authenticity_token</code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="3">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def index</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="4">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="5">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="6">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def tutor</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="7">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="8">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="9">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def login</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="10">
-          
-          
-          <code class="ruby">    email = params[:email]</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="11">
-          
-          
-          <code class="ruby">    password = params[:password]</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="12">
-          
-          
-          <code class="ruby">	if Tutor.where(email: email).exists?</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="13">
-          
-          
-          <code class="ruby">		params[:id] = Tutor.where(email: email).first.id</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="14">
-          
-          
-          <code class="ruby">		flash[:notice] = &quot;Welcome back&quot;</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="15">
-          
-          
-          <code class="ruby">		redirect_to tutor_path(params[:id])</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="16">
-          
-          
-          <code class="ruby">		return</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="17">
-          
-          
-          <code class="ruby">	end </code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="18">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="19">
-          
-          
-          <code class="ruby">	respond_to do |format|</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="20">
-          
-          
-          <code class="ruby">	  	flash[:notice] = &quot;Email &#39;#{email}&#39; does not exists.&quot;</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="21">
-          
-          
-          <code class="ruby">	  	format.html {redirect_to welcome_tutor_path}</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="22">
-          
-          
-          <code class="ruby">	  	format.json { head :no_content }</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="23">
-          
-          
-          <code class="ruby">	end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="24">
-          
-          
-          <code class="ruby">  	</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="25">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="26">
-          
-          
-          <code class="ruby">end</code>
-        </li>
-      
-    </ol>
-  </pre>
-</div>
-
-      
-        <div class="source_table" id="5975818c13bc92d2fb951b5f1f5cc20cfd8502c9">
+        <div class="source_table" id="8174061109bdf438bd81a1431bbeb40d3abf5400">
   <div class="header">
     <h3>app/helpers/admins_helper.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -6734,7 +1911,7 @@
 </div>
 
       
-        <div class="source_table" id="157ad42dedfca6052397934d1e6eebcae5b4dd40">
+        <div class="source_table" id="9bad7c699cc5787d4dd55525e67e3d066b88d4ae">
   <div class="header">
     <h3>app/helpers/application_helper.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -6765,7 +1942,7 @@
 </div>
 
       
-        <div class="source_table" id="0500870e5011744fa2d267fefc77606811ae5d3d">
+        <div class="source_table" id="fe604199a4ed8fdcbb4d51d6b67c878119cdcbbd">
   <div class="header">
     <h3>app/helpers/courses_helper.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -6796,7 +1973,7 @@
 </div>
 
       
-        <div class="source_table" id="ee840b6e77149293e2cbb55a91b7b554bc398886">
+        <div class="source_table" id="8670736eb220f620982229f8cb452c57652ae8cf">
   <div class="header">
     <h3>app/helpers/evaluations_helper.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -6827,7 +2004,7 @@
 </div>
 
       
-        <div class="source_table" id="d61ada6e6be49a1e013bf9dc24b962f23be58a7d">
+        <div class="source_table" id="146cc1182cacd0df31885e1dc2d3fd7c3cd39fff">
   <div class="header">
     <h3>app/helpers/requests_helper.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -6858,7 +2035,7 @@
 </div>
 
       
-        <div class="source_table" id="6c2235a720ab247c02c3f5d721ba7098867caed4">
+        <div class="source_table" id="38e186ca1e33138aa22d4a7dd86d99372897922a">
   <div class="header">
     <h3>app/helpers/tutees_helper.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -6889,7 +2066,7 @@
 </div>
 
       
-        <div class="source_table" id="eada9445989d0eeb8bd69869dfa7582fe658d6f8">
+        <div class="source_table" id="cde4c3ca08f2c62dd99442bce16aea82b9764943">
   <div class="header">
     <h3>app/helpers/tutors_helper.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -6920,7 +2097,7 @@
 </div>
 
       
-        <div class="source_table" id="a2c664dea4ddef56052d946c1476a954a8770a87">
+        <div class="source_table" id="a96b9ddf6487918cbba8dfa313220d61343625a2">
   <div class="header">
     <h3>app/helpers/welcome_helper.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -6951,14 +2128,14 @@
 </div>
 
       
-        <div class="source_table" id="ed8eb0e3b50404db2f47123f1a5cfa375edb7c0c">
+        <div class="source_table" id="ba36ede5cd2ce9189483bb4420c2f93c5c404e3e">
   <div class="header">
     <h3>app/models/admin.rb</h3>
-    <h4><span class="green">90.48 %</span> covered</h4>
+    <h4><span class="red">71.43 %</span> covered</h4>
     <div>
       <b>21</b> relevant lines. 
-      <span class="green"><b>19</b> lines covered</span> and
-      <span class="red"><b>2</b> lines missed.</span>
+      <span class="green"><b>15</b> lines covered</span> and
+      <span class="red"><b>6</b> lines missed.</span>
     </div>
   </div>
   
@@ -7001,8 +2178,8 @@
           <code class="ruby">      # All admins access/modify the same row</code>
         </li>
       
-        <li class="covered" data-hits="266" data-linenumber="7">
-          <span class="hits">266</span>
+        <li class="covered" data-hits="8" data-linenumber="7">
+          <span class="hits">8</span>
           
           <code class="ruby">      return 1</code>
         </li>
@@ -7031,8 +2208,8 @@
           <code class="ruby">      # Can not be all caps else _formatted functions wont work</code>
         </li>
       
-        <li class="covered" data-hits="28" data-linenumber="12">
-          <span class="hits">28</span>
+        <li class="missed" data-hits="0" data-linenumber="12">
+          
           
           <code class="ruby">      return %w(Spring Fall Summer)</code>
         </li>
@@ -7061,26 +2238,26 @@
           <code class="ruby">      # do some error handing for test cases</code>
         </li>
       
-        <li class="covered" data-hits="140" data-linenumber="17">
-          <span class="hits">140</span>
+        <li class="covered" data-hits="8" data-linenumber="17">
+          <span class="hits">8</span>
           
           <code class="ruby">      @admin = self.find_by_id(master_admin_index)</code>
         </li>
       
-        <li class="covered" data-hits="140" data-linenumber="18">
-          <span class="hits">140</span>
+        <li class="covered" data-hits="8" data-linenumber="18">
+          <span class="hits">8</span>
           
           <code class="ruby">      if @admin</code>
         </li>
       
-        <li class="covered" data-hits="90" data-linenumber="19">
-          <span class="hits">90</span>
+        <li class="missed" data-hits="0" data-linenumber="19">
+          
           
           <code class="ruby">        return @admin.current_semester</code>
         </li>
       
-        <li class="covered" data-hits="50" data-linenumber="20">
-          <span class="hits">50</span>
+        <li class="covered" data-hits="8" data-linenumber="20">
+          <span class="hits">8</span>
           
           <code class="ruby">      elsif Course.first</code>
         </li>
@@ -7091,8 +2268,8 @@
           <code class="ruby">        # return first semester for testing or just in case admin hasnt been created</code>
         </li>
       
-        <li class="covered" data-hits="30" data-linenumber="22">
-          <span class="hits">30</span>
+        <li class="covered" data-hits="8" data-linenumber="22">
+          <span class="hits">8</span>
           
           <code class="ruby">        return Course.first.semester</code>
         </li>
@@ -7133,8 +2310,8 @@
           <code class="ruby">    def current_semester_formatted</code>
         </li>
       
-        <li class="covered" data-hits="31" data-linenumber="29">
-          <span class="hits">31</span>
+        <li class="missed" data-hits="0" data-linenumber="29">
+          
           
           <code class="ruby">      return self.current_semester.gsub(/(?&lt;=[a-z])(?=[0-9])/, &#39; &#39;)</code>
         </li>
@@ -7199,8 +2376,8 @@
           <code class="ruby">    def validate_year(year)</code>
         </li>
       
-        <li class="covered" data-hits="3" data-linenumber="40">
-          <span class="hits">3</span>
+        <li class="missed" data-hits="0" data-linenumber="40">
+          
           
           <code class="ruby">      return year.match(/^\d{4}$/)</code>
         </li>
@@ -7228,7 +2405,7 @@
 </div>
 
       
-        <div class="source_table" id="23394b3f34a64f526639f3bf44d9b73f35adbdea">
+        <div class="source_table" id="c0758cf22796106a1de667c7204b522832d1bc88">
   <div class="header">
     <h3>app/models/application_record.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -7265,14 +2442,14 @@
 </div>
 
       
-        <div class="source_table" id="6a19aefe4ad708ce3fb1f629b0687b1e78a14c61">
+        <div class="source_table" id="caae2e678adf27d6731b59a731901b98aa388b56">
   <div class="header">
     <h3>app/models/berkeley_class.rb</h3>
-    <h4><span class="green">100.0 %</span> covered</h4>
+    <h4><span class="red">25.0 %</span> covered</h4>
     <div>
       <b>12</b> relevant lines. 
-      <span class="green"><b>12</b> lines covered</span> and
-      <span class="red"><b>0</b> lines missed.</span>
+      <span class="green"><b>3</b> lines covered</span> and
+      <span class="red"><b>9</b> lines missed.</span>
     </div>
   </div>
   
@@ -7297,26 +2474,26 @@
           <code class="ruby">	def true_classes</code>
         </li>
       
-        <li class="covered" data-hits="16" data-linenumber="4">
-          <span class="hits">16</span>
+        <li class="missed" data-hits="0" data-linenumber="4">
+          
           
           <code class="ruby">		@preferred_classes = []</code>
         </li>
       
-        <li class="covered" data-hits="16" data-linenumber="5">
-          <span class="hits">16</span>
+        <li class="missed" data-hits="0" data-linenumber="5">
+          
           
           <code class="ruby">		self.attributes.each_pair do |name, value|</code>
         </li>
       
-        <li class="covered" data-hits="160" data-linenumber="6">
-          <span class="hits">160</span>
+        <li class="missed" data-hits="0" data-linenumber="6">
+          
           
           <code class="ruby">	      	if value == true</code>
         </li>
       
-        <li class="covered" data-hits="43" data-linenumber="7">
-          <span class="hits">43</span>
+        <li class="missed" data-hits="0" data-linenumber="7">
+          
           
           <code class="ruby">	        	@preferred_classes.push(name)</code>
         </li>
@@ -7333,8 +2510,8 @@
           <code class="ruby">      	end</code>
         </li>
       
-        <li class="covered" data-hits="16" data-linenumber="10">
-          <span class="hits">16</span>
+        <li class="missed" data-hits="0" data-linenumber="10">
+          
           
           <code class="ruby">      	@preferred_classes</code>
         </li>
@@ -7357,20 +2534,20 @@
           <code class="ruby">	def self.all_classes</code>
         </li>
       
-        <li class="covered" data-hits="21" data-linenumber="14">
-          <span class="hits">21</span>
+        <li class="missed" data-hits="0" data-linenumber="14">
+          
           
           <code class="ruby">		@classes = []</code>
         </li>
       
-        <li class="covered" data-hits="21" data-linenumber="15">
-          <span class="hits">21</span>
+        <li class="missed" data-hits="0" data-linenumber="15">
+          
           
           <code class="ruby">		BerkeleyClass.column_names.each do |colunm_name|</code>
         </li>
       
-        <li class="covered" data-hits="210" data-linenumber="16">
-          <span class="hits">210</span>
+        <li class="missed" data-hits="0" data-linenumber="16">
+          
           
           <code class="ruby">			@classes.push(colunm_name) if colunm_name != &quot;id&quot;</code>
         </li>
@@ -7381,8 +2558,8 @@
           <code class="ruby">		end</code>
         </li>
       
-        <li class="covered" data-hits="21" data-linenumber="18">
-          <span class="hits">21</span>
+        <li class="missed" data-hits="0" data-linenumber="18">
+          
           
           <code class="ruby">		@classes</code>
         </li>
@@ -7410,14 +2587,14 @@
 </div>
 
       
-        <div class="source_table" id="c36bb0d35cb766151604bff00688dbba1e12b94d">
+        <div class="source_table" id="0d166496ac53fb4ec86cb3c836ce22d2bbf6d338">
   <div class="header">
     <h3>app/models/course.rb</h3>
-    <h4><span class="green">95.65 %</span> covered</h4>
+    <h4><span class="red">39.13 %</span> covered</h4>
     <div>
       <b>23</b> relevant lines. 
-      <span class="green"><b>22</b> lines covered</span> and
-      <span class="red"><b>1</b> lines missed.</span>
+      <span class="green"><b>9</b> lines covered</span> and
+      <span class="red"><b>14</b> lines missed.</span>
     </div>
   </div>
   
@@ -7454,8 +2631,8 @@
           <code class="ruby">    def current_semester</code>
         </li>
       
-        <li class="covered" data-hits="109" data-linenumber="6">
-          <span class="hits">109</span>
+        <li class="covered" data-hits="8" data-linenumber="6">
+          <span class="hits">8</span>
           
           <code class="ruby">      return Admin.current_semester</code>
         </li>
@@ -7478,14 +2655,14 @@
           <code class="ruby">    def current_courses_formatted</code>
         </li>
       
-        <li class="covered" data-hits="12" data-linenumber="10">
-          <span class="hits">12</span>
+        <li class="missed" data-hits="0" data-linenumber="10">
+          
           
           <code class="ruby">      formated_string = &quot;&quot;</code>
         </li>
       
-        <li class="covered" data-hits="12" data-linenumber="11">
-          <span class="hits">12</span>
+        <li class="missed" data-hits="0" data-linenumber="11">
+          
           
           <code class="ruby">      self.current_active_courses.pluck(:name).each do |course_name|</code>
         </li>
@@ -7496,8 +2673,8 @@
           <code class="ruby">        # temp fix for nil name in database</code>
         </li>
       
-        <li class="covered" data-hits="34" data-linenumber="13">
-          <span class="hits">34</span>
+        <li class="missed" data-hits="0" data-linenumber="13">
+          
           
           <code class="ruby">        if course_name.nil? </code>
         </li>
@@ -7514,8 +2691,8 @@
           <code class="ruby">        end</code>
         </li>
       
-        <li class="covered" data-hits="34" data-linenumber="16">
-          <span class="hits">34</span>
+        <li class="missed" data-hits="0" data-linenumber="16">
+          
           
           <code class="ruby">        formated_string += course_name +&quot;\r\n&quot;</code>
         </li>
@@ -7526,8 +2703,8 @@
           <code class="ruby">      end</code>
         </li>
       
-        <li class="covered" data-hits="12" data-linenumber="18">
-          <span class="hits">12</span>
+        <li class="missed" data-hits="0" data-linenumber="18">
+          
           
           <code class="ruby">      return formated_string[0..-2] # removes the final \n from the string</code>
         </li>
@@ -7550,8 +2727,8 @@
           <code class="ruby">    def current_active_courses</code>
         </li>
       
-        <li class="covered" data-hits="24" data-linenumber="22">
-          <span class="hits">24</span>
+        <li class="missed" data-hits="0" data-linenumber="22">
+          
           
           <code class="ruby">      self.where(:semester =&gt; self.current_semester, :active =&gt; true)</code>
         </li>
@@ -7580,8 +2757,8 @@
           <code class="ruby">    def course_array</code>
         </li>
       
-        <li class="covered" data-hits="18" data-linenumber="27">
-          <span class="hits">18</span>
+        <li class="missed" data-hits="0" data-linenumber="27">
+          
           
           <code class="ruby">      self.current_active_courses.all.map { |course| [course.name, course.id] }</code>
         </li>
@@ -7610,8 +2787,8 @@
           <code class="ruby">    def update_courses(courses)</code>
         </li>
       
-        <li class="covered" data-hits="44" data-linenumber="32">
-          <span class="hits">44</span>
+        <li class="missed" data-hits="0" data-linenumber="32">
+          
           
           <code class="ruby">      courses = courses.to_s.split(&quot;\r\n&quot;).map { |c| c.upcase.gsub(/\s+/, &quot;&quot;) }.map{ |name| {:name =&gt; name, :semester =&gt; self.current_semester}} #split, remove spaces/capitialize, and turn into an array of hashes</code>
         </li>
@@ -7658,8 +2835,8 @@
           <code class="ruby">      # update all current_semester_courses to be inactive</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="40">
-          <span class="hits">6</span>
+        <li class="missed" data-hits="0" data-linenumber="40">
+          
           
           <code class="ruby">      self.where(semester: self.current_semester).update_all(:active =&gt; false)</code>
         </li>
@@ -7682,20 +2859,20 @@
           <code class="ruby">      # find existing courses and update to active or create new courses</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="44">
-          <span class="hits">6</span>
+        <li class="missed" data-hits="0" data-linenumber="44">
+          
           
           <code class="ruby">      courses.each do |course|</code>
         </li>
       
-        <li class="covered" data-hits="19" data-linenumber="45">
-          <span class="hits">19</span>
+        <li class="missed" data-hits="0" data-linenumber="45">
+          
           
           <code class="ruby">        @c = self.where(course).first_or_create</code>
         </li>
       
-        <li class="covered" data-hits="19" data-linenumber="46">
-          <span class="hits">19</span>
+        <li class="missed" data-hits="0" data-linenumber="46">
+          
           
           <code class="ruby">        @c.update(:active =&gt; true)</code>
         </li>
@@ -7718,8 +2895,8 @@
           <code class="ruby">      # verify that the number of active courses is now the same.</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="50">
-          <span class="hits">6</span>
+        <li class="missed" data-hits="0" data-linenumber="50">
+          
           
           <code class="ruby">      return self.current_active_courses.count == courses.uniq.count</code>
         </li>
@@ -7747,7 +2924,7 @@
 </div>
 
       
-        <div class="source_table" id="a8dab1bd2236a88b9d4433fed7290f90a331f17c">
+        <div class="source_table" id="37e78311eb6a616ed6f98daf673c805fd18ac3c3">
   <div class="header">
     <h3>app/models/evaluation.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -7886,14 +3063,14 @@
 </div>
 
       
-        <div class="source_table" id="a06b8312d493c33918013966dc6e231dad452ab1">
+        <div class="source_table" id="001038965feebf93297ee68ff8f797207e003379">
   <div class="header">
     <h3>app/models/meeting.rb</h3>
-    <h4><span class="yellow">88.89 %</span> covered</h4>
+    <h4><span class="red">66.67 %</span> covered</h4>
     <div>
       <b>9</b> relevant lines. 
-      <span class="green"><b>8</b> lines covered</span> and
-      <span class="red"><b>1</b> lines missed.</span>
+      <span class="green"><b>6</b> lines covered</span> and
+      <span class="red"><b>3</b> lines missed.</span>
     </div>
   </div>
   
@@ -7942,8 +3119,8 @@
           <code class="ruby">  def isExpired</code>
         </li>
       
-        <li class="covered" data-hits="1" data-linenumber="8">
-          <span class="hits">1</span>
+        <li class="missed" data-hits="0" data-linenumber="8">
+          
           
           <code class="ruby">  	if self.set_time.nil?</code>
         </li>
@@ -7960,8 +3137,8 @@
           <code class="ruby">  	end</code>
         </li>
       
-        <li class="covered" data-hits="1" data-linenumber="11">
-          <span class="hits">1</span>
+        <li class="missed" data-hits="0" data-linenumber="11">
+          
           
           <code class="ruby">	return self.set_time &lt; Time.now</code>
         </li>
@@ -7983,7 +3160,7 @@
 </div>
 
       
-        <div class="source_table" id="d1f41e6d2ac68e6d020f2b459532d1d034f6dfb5">
+        <div class="source_table" id="7e81e6f67b1cb076d882fe7f9c9f8d7b71018753">
   <div class="header">
     <h3>app/models/request.rb</h3>
     <h4><span class="yellow">87.5 %</span> covered</h4>
@@ -8068,14 +3245,14 @@
 </div>
 
       
-        <div class="source_table" id="6f1c6db58e84ab384da77bd2e24501c36decd7eb">
+        <div class="source_table" id="898264f6a5e28492d330c8895b520307769a6c39">
   <div class="header">
     <h3>app/models/tutee.rb</h3>
-    <h4><span class="green">100.0 %</span> covered</h4>
+    <h4><span class="red">65.0 %</span> covered</h4>
     <div>
       <b>60</b> relevant lines. 
-      <span class="green"><b>60</b> lines covered</span> and
-      <span class="red"><b>0</b> lines missed.</span>
+      <span class="green"><b>39</b> lines covered</span> and
+      <span class="red"><b>21</b> lines missed.</span>
     </div>
   </div>
   
@@ -8244,14 +3421,14 @@
           <code class="ruby">  def validate_birth</code>
         </li>
       
-        <li class="covered" data-hits="122" data-linenumber="28">
-          <span class="hits">122</span>
+        <li class="covered" data-hits="10" data-linenumber="28">
+          <span class="hits">10</span>
           
           <code class="ruby">    if birthdate.present? &amp;&amp; birthdate &gt; Time.now</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="29">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="29">
+          
           
           <code class="ruby">      errors.add(:birthdate, &#39;Your birthdate cannot be in the future&#39;)</code>
         </li>
@@ -8292,8 +3469,8 @@
           <code class="ruby">    def get_cs61a_privileged_students</code>
         </li>
       
-        <li class="covered" data-hits="18" data-linenumber="36">
-          <span class="hits">18</span>
+        <li class="missed" data-hits="0" data-linenumber="36">
+          
           
           <code class="ruby">      return self.where(:privilege =&gt; &quot;cs61a&quot;)</code>
         </li>
@@ -8310,8 +3487,8 @@
           <code class="ruby">    def get_current_cs61a_sids_formatted</code>
         </li>
       
-        <li class="covered" data-hits="16" data-linenumber="39">
-          <span class="hits">16</span>
+        <li class="missed" data-hits="0" data-linenumber="39">
+          
           
           <code class="ruby">      return format_sids(self.get_cs61a_privileged_students)</code>
         </li>
@@ -8334,8 +3511,8 @@
           <code class="ruby">    def get_cs61b_privileged_students</code>
         </li>
       
-        <li class="covered" data-hits="18" data-linenumber="43">
-          <span class="hits">18</span>
+        <li class="missed" data-hits="0" data-linenumber="43">
+          
           
           <code class="ruby">      return self.where(:privilege =&gt; &quot;cs61b&quot;)</code>
         </li>
@@ -8352,8 +3529,8 @@
           <code class="ruby">    def get_current_cs61b_sids_formatted</code>
         </li>
       
-        <li class="covered" data-hits="16" data-linenumber="46">
-          <span class="hits">16</span>
+        <li class="missed" data-hits="0" data-linenumber="46">
+          
           
           <code class="ruby">      return format_sids(self.get_cs61b_privileged_students)</code>
         </li>
@@ -8376,8 +3553,8 @@
           <code class="ruby">    def get_cs61c_privileged_students</code>
         </li>
       
-        <li class="covered" data-hits="18" data-linenumber="50">
-          <span class="hits">18</span>
+        <li class="missed" data-hits="0" data-linenumber="50">
+          
           
           <code class="ruby">      return self.where(:privilege =&gt; &quot;cs61c&quot;)</code>
         </li>
@@ -8394,8 +3571,8 @@
           <code class="ruby">    def get_current_cs61c_sids_formatted</code>
         </li>
       
-        <li class="covered" data-hits="16" data-linenumber="53">
-          <span class="hits">16</span>
+        <li class="missed" data-hits="0" data-linenumber="53">
+          
           
           <code class="ruby">      return format_sids(self.get_cs61c_privileged_students)</code>
         </li>
@@ -8418,8 +3595,8 @@
           <code class="ruby">    def get_cs70_privileged_students</code>
         </li>
       
-        <li class="covered" data-hits="18" data-linenumber="57">
-          <span class="hits">18</span>
+        <li class="missed" data-hits="0" data-linenumber="57">
+          
           
           <code class="ruby">      return self.where(:privilege =&gt; &quot;cs70&quot;)</code>
         </li>
@@ -8436,8 +3613,8 @@
           <code class="ruby">    def get_current_cs70_sids_formatted</code>
         </li>
       
-        <li class="covered" data-hits="16" data-linenumber="60">
-          <span class="hits">16</span>
+        <li class="missed" data-hits="0" data-linenumber="60">
+          
           
           <code class="ruby">      return format_sids(self.get_cs70_privileged_students)</code>
         </li>
@@ -8460,20 +3637,20 @@
           <code class="ruby">    def format_sids(some_search_function)</code>
         </li>
       
-        <li class="covered" data-hits="64" data-linenumber="64">
-          <span class="hits">64</span>
+        <li class="missed" data-hits="0" data-linenumber="64">
+          
           
           <code class="ruby">      formated_string = &quot;&quot;</code>
         </li>
       
-        <li class="covered" data-hits="64" data-linenumber="65">
-          <span class="hits">64</span>
+        <li class="missed" data-hits="0" data-linenumber="65">
+          
           
           <code class="ruby">      some_search_function.pluck(:sid).each do |sid|</code>
         </li>
       
-        <li class="covered" data-hits="64" data-linenumber="66">
-          <span class="hits">64</span>
+        <li class="missed" data-hits="0" data-linenumber="66">
+          
           
           <code class="ruby">        formated_string += (sid.to_s) + &quot;\r\n&quot;</code>
         </li>
@@ -8484,8 +3661,8 @@
           <code class="ruby">      end</code>
         </li>
       
-        <li class="covered" data-hits="64" data-linenumber="68">
-          <span class="hits">64</span>
+        <li class="missed" data-hits="0" data-linenumber="68">
+          
           
           <code class="ruby">      return formated_string[0..-2] # removes the final \n from the string</code>
         </li>
@@ -8508,8 +3685,8 @@
           <code class="ruby">    def update_cs61a_privileges(sids)</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="72">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="72">
+          
           
           <code class="ruby">      return update_privileges(sids, self.get_cs61a_privileged_students, &quot;cs61a&quot;)</code>
         </li>
@@ -8526,8 +3703,8 @@
           <code class="ruby">    def update_cs61b_privileges(sids)</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="75">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="75">
+          
           
           <code class="ruby">      return update_privileges(sids, self.get_cs61b_privileged_students, &quot;cs61b&quot;)</code>
         </li>
@@ -8544,8 +3721,8 @@
           <code class="ruby">    def update_cs61c_privileges(sids)</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="78">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="78">
+          
           
           <code class="ruby">      return update_privileges(sids, self.get_cs61c_privileged_students, &quot;cs61c&quot;)</code>
         </li>
@@ -8562,8 +3739,8 @@
           <code class="ruby">    def update_cs70_privileges(sids)</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="81">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="81">
+          
           
           <code class="ruby">      return update_privileges(sids, self.get_cs70_privileged_students, &quot;cs70&quot;)</code>
         </li>
@@ -8580,8 +3757,8 @@
           <code class="ruby">    def update_privileges(sids, some_search_function, privilege_to_change_to)</code>
         </li>
       
-        <li class="covered" data-hits="20" data-linenumber="84">
-          <span class="hits">20</span>
+        <li class="missed" data-hits="0" data-linenumber="84">
+          
           
           <code class="ruby">      sids = sids.to_s.split(&quot;\r\n&quot;).map { |c| c.gsub(/\s+/, &quot;&quot;) }#.map{ |sid| {:sid =&gt; sid}} #split, remove spaces</code>
         </li>
@@ -8604,8 +3781,8 @@
           <code class="ruby">      # update all students currently with that privilege to not have that privilege anymore</code>
         </li>
       
-        <li class="covered" data-hits="8" data-linenumber="88">
-          <span class="hits">8</span>
+        <li class="missed" data-hits="0" data-linenumber="88">
+          
           
           <code class="ruby">      some_search_function.update_all(:privilege =&gt; &quot;No&quot;)</code>
         </li>
@@ -8628,14 +3805,14 @@
           <code class="ruby">      # find students with a given sid and update to have that privilege, do nothing if sid doesnt correspond to a tutee account.</code>
         </li>
       
-        <li class="covered" data-hits="8" data-linenumber="92">
-          <span class="hits">8</span>
+        <li class="missed" data-hits="0" data-linenumber="92">
+          
           
           <code class="ruby">      sids.each do |sid|</code>
         </li>
       
-        <li class="covered" data-hits="12" data-linenumber="93">
-          <span class="hits">12</span>
+        <li class="missed" data-hits="0" data-linenumber="93">
+          
           
           <code class="ruby">        @tutee = self.find_by_sid(sid).try(:update_attributes, {:privilege =&gt; privilege_to_change_to})</code>
         </li>
@@ -8693,14 +3870,14 @@
 </div>
 
       
-        <div class="source_table" id="b113cbc4b89ebb17c37722a9a037e68c18659ab4">
+        <div class="source_table" id="b55b68575b893af08bab0c14ccececbeaeb59f40">
   <div class="header">
     <h3>app/models/tutor.rb</h3>
-    <h4><span class="red">65.63 %</span> covered</h4>
+    <h4><span class="red">46.88 %</span> covered</h4>
     <div>
       <b>32</b> relevant lines. 
-      <span class="green"><b>21</b> lines covered</span> and
-      <span class="red"><b>11</b> lines missed.</span>
+      <span class="green"><b>15</b> lines covered</span> and
+      <span class="red"><b>17</b> lines missed.</span>
     </div>
   </div>
   
@@ -8815,14 +3992,14 @@
           <code class="ruby">	def self.total_hours_helper tutor</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="19">
-          <span class="hits">6</span>
+        <li class="missed" data-hits="0" data-linenumber="19">
+          
           
           <code class="ruby">		@all_evals = tutor.evaluations</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="20">
-          <span class="hits">6</span>
+        <li class="missed" data-hits="0" data-linenumber="20">
+          
           
           <code class="ruby">		return @all_evals.sum(:hours)</code>
         </li>
@@ -8845,8 +4022,8 @@
           <code class="ruby">	def self.hours_this_week_helper tutor</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="24">
-          <span class="hits">6</span>
+        <li class="missed" data-hits="0" data-linenumber="24">
+          
           
           <code class="ruby">		return tutor.evaluations.where(created_at: Time.now.beginning_of_week.strftime(&quot;%Y-%m-%d&quot;)..Time.now).sum(:hours)</code>
         </li>
@@ -8869,20 +4046,20 @@
           <code class="ruby">	def self.average_hours_helper tutor</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="28">
-          <span class="hits">6</span>
+        <li class="missed" data-hits="0" data-linenumber="28">
+          
           
           <code class="ruby">		all_evals = tutor.evaluations</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="29">
-          <span class="hits">6</span>
+        <li class="missed" data-hits="0" data-linenumber="29">
+          
           
           <code class="ruby">		if all_evals.empty?</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="30">
-          <span class="hits">6</span>
+        <li class="missed" data-hits="0" data-linenumber="30">
+          
           
           <code class="ruby">			return &quot;Not Available&quot;</code>
         </li>
@@ -8988,7 +4165,7 @@
 </div>
 
       
-        <div class="source_table" id="a026b7c087fdf4770f19267cf79398a4b36d8090">
+        <div class="source_table" id="37a71bac709a2d21c55c765a7326e89a20ae6c6d">
   <div class="header">
     <h3>config/application.rb</h3>
     <h4><span class="green">95.24 %</span> covered</h4>
@@ -9253,7 +4430,7 @@
 </div>
 
       
-        <div class="source_table" id="650b852c920f608e7b28ed1c5adcff90e240c826">
+        <div class="source_table" id="7176a892bb03d241bded131a44ab6445892629b4">
   <div class="header">
     <h3>config/boot.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -9296,7 +4473,7 @@
 </div>
 
       
-        <div class="source_table" id="41b3055594e2c27828bc007edf473f6b23c3e034">
+        <div class="source_table" id="84725d0e425b9b8838b85a83158d6c10dfa3029c">
   <div class="header">
     <h3>config/environment.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -9345,7 +4522,7 @@
 </div>
 
       
-        <div class="source_table" id="45dff4e870289555106dbb04846b2f20bb5d9874">
+        <div class="source_table" id="58de7636cde5ebe59baff28f1fa913e60a193d76">
   <div class="header">
     <h3>config/environments/test.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -9646,7 +4823,7 @@
 </div>
 
       
-        <div class="source_table" id="7f96744ec93720b10c020f64b2ce3d10cf30d1ca">
+        <div class="source_table" id="4980793726624cbc48543b50736e80fc10b9c40a">
   <div class="header">
     <h3>config/initializers/application_controller_renderer.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -9713,7 +4890,7 @@
 </div>
 
       
-        <div class="source_table" id="669c57fd801262bc1eca06257db2ea76f846ce97">
+        <div class="source_table" id="a7dd41f082d62e0cd7f82daf179d6ac58c264495">
   <div class="header">
     <h3>config/initializers/assets.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -9954,7 +5131,7 @@
 </div>
 
       
-        <div class="source_table" id="86c9fe736c478c132175357e415f09057c9cb22f">
+        <div class="source_table" id="114998ace16fe5270a44ab8694a882baca0dca8f">
   <div class="header">
     <h3>config/initializers/backtrace_silencers.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -10015,7 +5192,7 @@
 </div>
 
       
-        <div class="source_table" id="8c23c254c5add7422077f0dffbd88bdcae4aefa3">
+        <div class="source_table" id="c85d6a49c112b1bdf3ca1963ccb88203b103bd9a">
   <div class="header">
     <h3>config/initializers/content_security_policy.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -10184,7 +5361,7 @@
 </div>
 
       
-        <div class="source_table" id="2014a789c0f1bbb9749f8254e50c595fce7756bb">
+        <div class="source_table" id="0958624c5e7ab7938e278f1cc736498db7793fbd">
   <div class="header">
     <h3>config/initializers/cookies_serializer.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -10233,7 +5410,7 @@
 </div>
 
       
-        <div class="source_table" id="90d2e93d40f0a63eed06f24762e7bb6e99f60000">
+        <div class="source_table" id="bf5d9587b4e4271e93155f9675d2ea51ebfae3b6">
   <div class="header">
     <h3>config/initializers/devise.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -12046,7 +7223,7 @@
 </div>
 
       
-        <div class="source_table" id="94bb639936dc44aaf46b9363fce6284c70d06061">
+        <div class="source_table" id="d6eca56e4cdde30b8100afd713c8a8e9c0a8a389">
   <div class="header">
     <h3>config/initializers/filter_parameter_logging.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -12089,7 +7266,7 @@
 </div>
 
       
-        <div class="source_table" id="2f1857a4f6e793e01c337219abd8b8bb221c4680">
+        <div class="source_table" id="e5fda2caad7f6fa775cfe1d4b7371d3a2cf8d6a8">
   <div class="header">
     <h3>config/initializers/inflections.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -12204,7 +7381,7 @@
 </div>
 
       
-        <div class="source_table" id="12d98f3b79c7e3b406a427cb964988d8cb6c0e00">
+        <div class="source_table" id="53e806872a9385ef0f5f4a84502f4628c57ce7c8">
   <div class="header">
     <h3>config/initializers/mime_types.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -12247,7 +7424,7 @@
 </div>
 
       
-        <div class="source_table" id="e50fe79f6dbbbd9fe24f6096e65082fa7ea97c35">
+        <div class="source_table" id="02433b95e54fd3b29322c36cb5f27953ea897ceb">
   <div class="header">
     <h3>config/initializers/setup_mail.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -12320,7 +7497,7 @@
 </div>
 
       
-        <div class="source_table" id="6bc89e4562d7369faf66e5bcca09f5e738432d6b">
+        <div class="source_table" id="32dba3231c8cb4f040bc0b88ba6caf27e70cbe19">
   <div class="header">
     <h3>config/initializers/wrap_parameters.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -12423,7 +7600,7 @@
 </div>
 
       
-        <div class="source_table" id="f2d089850d0420171a8572ab505a14539e265f95">
+        <div class="source_table" id="19ebe1b2ad641329505f4a87fd70931555dced54">
   <div class="header">
     <h3>config/routes.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -12820,7 +7997,7 @@
 </div>
 
       
-        <div class="source_table" id="7e1cb99750c0361be6f1879c3cb343c5a9c9912e">
+        <div class="source_table" id="19988ee7766b83683bcb98f2bb3173ee45d97823">
   <div class="header">
     <h3>features/step_definitions/tutors_steps.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -12840,14 +8017,14 @@
           <code class="ruby">Given /the following tutors exist/ do |tutors_table|</code>
         </li>
       
-        <li class="covered" data-hits="17" data-linenumber="2">
-          <span class="hits">17</span>
+        <li class="covered" data-hits="5" data-linenumber="2">
+          <span class="hits">5</span>
           
           <code class="ruby">  tutors_table.hashes.each do |tutor|</code>
         </li>
       
-        <li class="covered" data-hits="27" data-linenumber="3">
-          <span class="hits">27</span>
+        <li class="covered" data-hits="5" data-linenumber="3">
+          <span class="hits">5</span>
           
           <code class="ruby">    Tutor.create tutor</code>
         </li>
@@ -12876,14 +8053,14 @@
           <code class="ruby">Given /the following berkeley_classes exist/ do |berkeley_classes_table|</code>
         </li>
       
-        <li class="covered" data-hits="14" data-linenumber="8">
-          <span class="hits">14</span>
+        <li class="covered" data-hits="5" data-linenumber="8">
+          <span class="hits">5</span>
           
           <code class="ruby">  berkeley_classes_table.hashes.each do |berkeley_class|</code>
         </li>
       
-        <li class="covered" data-hits="20" data-linenumber="9">
-          <span class="hits">20</span>
+        <li class="covered" data-hits="5" data-linenumber="9">
+          <span class="hits">5</span>
           
           <code class="ruby">    BerkeleyClass.create berkeley_class</code>
         </li>
@@ -12905,14 +8082,14 @@
 </div>
 
       
-        <div class="source_table" id="cd7c47cc1a473bdb385bce3496b759966e220555">
+        <div class="source_table" id="a47e690d440b7da1e9461757a9ab9d5261e44184">
   <div class="header">
     <h3>features/step_definitions/web_steps.rb</h3>
-    <h4><span class="green">91.67 %</span> covered</h4>
+    <h4><span class="red">62.5 %</span> covered</h4>
     <div>
       <b>24</b> relevant lines. 
-      <span class="green"><b>22</b> lines covered</span> and
-      <span class="red"><b>2</b> lines missed.</span>
+      <span class="green"><b>15</b> lines covered</span> and
+      <span class="red"><b>9</b> lines missed.</span>
     </div>
   </div>
   
@@ -13249,8 +8426,8 @@
           <code class="ruby">When /^(?:|I )go to (.+)$/ do |page_name|</code>
         </li>
       
-        <li class="covered" data-hits="7" data-linenumber="56">
-          <span class="hits">7</span>
+        <li class="missed" data-hits="0" data-linenumber="56">
+          
           
           <code class="ruby">  visit path_to(page_name)</code>
         </li>
@@ -13303,8 +8480,8 @@
           <code class="ruby">  # click_link(link)</code>
         </li>
       
-        <li class="covered" data-hits="5" data-linenumber="65">
-          <span class="hits">5</span>
+        <li class="missed" data-hits="0" data-linenumber="65">
+          
           
           <code class="ruby">  first(:link, link, exact: true).click #handles ambiguous case </code>
         </li>
@@ -13501,8 +8678,8 @@
           <code class="ruby">When /^(?:|I )check &quot;([^&quot;]*)&quot;$/ do |field|</code>
         </li>
       
-        <li class="covered" data-hits="3" data-linenumber="98">
-          <span class="hits">3</span>
+        <li class="missed" data-hits="0" data-linenumber="98">
+          
           
           <code class="ruby">  check(field)</code>
         </li>
@@ -13525,8 +8702,8 @@
           <code class="ruby">When /^(?:|I )uncheck &quot;([^&quot;]*)&quot;$/ do |field|</code>
         </li>
       
-        <li class="covered" data-hits="3" data-linenumber="102">
-          <span class="hits">3</span>
+        <li class="missed" data-hits="0" data-linenumber="102">
+          
           
           <code class="ruby">  uncheck(field)</code>
         </li>
@@ -13705,14 +8882,14 @@
           <code class="ruby">Then /^(?:|I )should not see &quot;([^&quot;]*)&quot;$/ do |text|</code>
         </li>
       
-        <li class="covered" data-hits="17" data-linenumber="132">
-          <span class="hits">17</span>
+        <li class="missed" data-hits="0" data-linenumber="132">
+          
           
           <code class="ruby">  if page.respond_to? :should</code>
         </li>
       
-        <li class="covered" data-hits="17" data-linenumber="133">
-          <span class="hits">17</span>
+        <li class="missed" data-hits="0" data-linenumber="133">
+          
           
           <code class="ruby">    page.should have_no_content(text)</code>
         </li>
@@ -14503,8 +9680,8 @@
           <code class="ruby">When /^&quot;([^&quot;]*)&quot; is selected for &quot;([^&quot;]*)&quot;$/ do |selected_text, dropdown|</code>
         </li>
       
-        <li class="covered" data-hits="5" data-linenumber="265">
-          <span class="hits">5</span>
+        <li class="missed" data-hits="0" data-linenumber="265">
+          
           
           <code class="ruby">  select selected_text, :from =&gt; dropdown</code>
         </li>
@@ -14592,14 +9769,14 @@
 </div>
 
       
-        <div class="source_table" id="ee5d416283bd93619217f6c8e5c30aad4d558381">
+        <div class="source_table" id="49ffee01b9c9525d5032de98cb94f619755b16f7">
   <div class="header">
     <h3>features/step_denifition/admin_steps.rb</h3>
-    <h4><span class="green">100.0 %</span> covered</h4>
+    <h4><span class="red">25.64 %</span> covered</h4>
     <div>
       <b>78</b> relevant lines. 
-      <span class="green"><b>78</b> lines covered</span> and
-      <span class="red"><b>0</b> lines missed.</span>
+      <span class="green"><b>20</b> lines covered</span> and
+      <span class="red"><b>58</b> lines missed.</span>
     </div>
   </div>
   
@@ -14612,14 +9789,14 @@
           <code class="ruby">Given /the following admins exist/ do |admins_table|</code>
         </li>
       
-        <li class="covered" data-hits="25" data-linenumber="2">
-          <span class="hits">25</span>
+        <li class="missed" data-hits="0" data-linenumber="2">
+          
           
           <code class="ruby">  admins_table.hashes.each do |admin|</code>
         </li>
       
-        <li class="covered" data-hits="25" data-linenumber="3">
-          <span class="hits">25</span>
+        <li class="missed" data-hits="0" data-linenumber="3">
+          
           
           <code class="ruby">    Admin.create admin</code>
         </li>
@@ -14648,8 +9825,8 @@
           <code class="ruby">Then /I can see current semester &quot;(.*)&quot; title/ do |text|</code>
         </li>
       
-        <li class="covered" data-hits="3" data-linenumber="8">
-          <span class="hits">3</span>
+        <li class="missed" data-hits="0" data-linenumber="8">
+          
           
           <code class="ruby">  expect(page).to have_content(text)</code>
         </li>
@@ -14672,32 +9849,32 @@
           <code class="ruby">When /I make an update for current semester to &quot;(.*)&quot;/ do |text|</code>
         </li>
       
-        <li class="covered" data-hits="3" data-linenumber="12">
-          <span class="hits">3</span>
+        <li class="missed" data-hits="0" data-linenumber="12">
+          
           
           <code class="ruby">  input = text.split(&#39; &#39;)</code>
         </li>
       
-        <li class="covered" data-hits="3" data-linenumber="13">
-          <span class="hits">3</span>
+        <li class="missed" data-hits="0" data-linenumber="13">
+          
           
           <code class="ruby">  semester, year = input[0],  input[1]</code>
         </li>
       
-        <li class="covered" data-hits="3" data-linenumber="14">
-          <span class="hits">3</span>
+        <li class="missed" data-hits="0" data-linenumber="14">
+          
           
           <code class="ruby">  steps %Q{When I choose &quot;#{semester}&quot; from semester list}</code>
         </li>
       
-        <li class="covered" data-hits="3" data-linenumber="15">
-          <span class="hits">3</span>
+        <li class="missed" data-hits="0" data-linenumber="15">
+          
           
           <code class="ruby">  steps %Q{When I input year &quot;#{year}&quot; for current semester}</code>
         </li>
       
-        <li class="covered" data-hits="3" data-linenumber="16">
-          <span class="hits">3</span>
+        <li class="missed" data-hits="0" data-linenumber="16">
+          
           
           <code class="ruby">  click_button(&quot;update_current_semester&quot;)</code>
         </li>
@@ -14720,8 +9897,8 @@
           <code class="ruby">When /I choose &quot;(.*)&quot; from semester list/ do |semester|</code>
         </li>
       
-        <li class="covered" data-hits="9" data-linenumber="20">
-          <span class="hits">9</span>
+        <li class="missed" data-hits="0" data-linenumber="20">
+          
           
           <code class="ruby">  page.find(:xpath, &#39;//*[@id=&quot;update_current_semester_semester&quot;]&#39;,visible: false).all(:css, &#39;option&#39;).find { |o| o.text == semester }.select_option</code>
         </li>
@@ -14744,8 +9921,8 @@
           <code class="ruby">When /I input year &quot;(.*)&quot; for current semester/ do |year|</code>
         </li>
       
-        <li class="covered" data-hits="3" data-linenumber="24">
-          <span class="hits">3</span>
+        <li class="missed" data-hits="0" data-linenumber="24">
+          
           
           <code class="ruby">  page.find(:xpath, &#39;//*[@id=&quot;update_current_semester_year&quot;]&#39;).set(year)</code>
         </li>
@@ -14768,14 +9945,14 @@
           <code class="ruby">Then /I can see courses &quot;(.*)&quot;/ do |course_list|</code>
         </li>
       
-        <li class="covered" data-hits="10" data-linenumber="28">
-          <span class="hits">10</span>
+        <li class="missed" data-hits="0" data-linenumber="28">
+          
           
           <code class="ruby">  course_list.to_s.split(&quot;, &quot;).each do |course_name|</code>
         </li>
       
-        <li class="covered" data-hits="31" data-linenumber="29">
-          <span class="hits">31</span>
+        <li class="missed" data-hits="0" data-linenumber="29">
+          
           
           <code class="ruby">    expect(page).to have_content(course_name)</code>
         </li>
@@ -14804,8 +9981,8 @@
           <code class="ruby">Then /I can not see course &quot;(.*)&quot;/ do |course|</code>
         </li>
       
-        <li class="covered" data-hits="1" data-linenumber="34">
-          <span class="hits">1</span>
+        <li class="missed" data-hits="0" data-linenumber="34">
+          
           
           <code class="ruby">  expect(page).to have_no_content(course)</code>
         </li>
@@ -14828,14 +10005,14 @@
           <code class="ruby">Then /I can see tutor &quot;(.*)&quot; with tutor hours (.*)/ do |first,num|</code>
         </li>
       
-        <li class="covered" data-hits="3" data-linenumber="38">
-          <span class="hits">3</span>
+        <li class="missed" data-hits="0" data-linenumber="38">
+          
           
           <code class="ruby">  expect(page).to have_content(first)</code>
         </li>
       
-        <li class="covered" data-hits="3" data-linenumber="39">
-          <span class="hits">3</span>
+        <li class="missed" data-hits="0" data-linenumber="39">
+          
           
           <code class="ruby">  expect(page).to have_content(num)</code>
         </li>
@@ -14864,8 +10041,8 @@
           <code class="ruby">Then /I can see course &quot;(.*)&quot; only once/ do |course|</code>
         </li>
       
-        <li class="covered" data-hits="1" data-linenumber="44">
-          <span class="hits">1</span>
+        <li class="missed" data-hits="0" data-linenumber="44">
+          
           
           <code class="ruby">  expect(page).to have_content(course, maximum: 1)</code>
         </li>
@@ -14888,8 +10065,8 @@
           <code class="ruby">When /I make an update for courses to &quot;(.*)&quot;/ do |course_list|</code>
         </li>
       
-        <li class="covered" data-hits="4" data-linenumber="48">
-          <span class="hits">4</span>
+        <li class="missed" data-hits="0" data-linenumber="48">
+          
           
           <code class="ruby">  obj = page.find(:xpath, &#39;//*[@id=&quot;update_courses_courses&quot;]&#39;,visible: false)</code>
         </li>
@@ -14900,8 +10077,8 @@
           <code class="ruby">  # separate course list into a newline separated list rather than comma separated</code>
         </li>
       
-        <li class="covered" data-hits="4" data-linenumber="50">
-          <span class="hits">4</span>
+        <li class="missed" data-hits="0" data-linenumber="50">
+          
           
           <code class="ruby">  obj.set(course_list.to_s.gsub(/, /, &quot;\r\n&quot;))</code>
         </li>
@@ -14912,8 +10089,8 @@
           <code class="ruby">  # fill_in obj.field, with: course_list.to_s.gsub(/,/, &quot;/r/n&quot;)</code>
         </li>
       
-        <li class="covered" data-hits="4" data-linenumber="52">
-          <span class="hits">4</span>
+        <li class="missed" data-hits="0" data-linenumber="52">
+          
           
           <code class="ruby">  click_button(&quot;update_courses&quot;)</code>
         </li>
@@ -14936,20 +10113,20 @@
           <code class="ruby">When /I update admin password with password &quot;(.*)&quot; and confirmation password &quot;(.*)&quot;/ do |pass, confirmation|</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="56">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="56">
+          
           
           <code class="ruby">  page.find(:xpath, &#39;//*[@id=&quot;update_password_password&quot;]&#39;).set(pass)</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="57">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="57">
+          
           
           <code class="ruby">  page.find(:xpath, &#39;//*[@id=&quot;update_password_password_confirmation&quot;]&#39;).set(confirmation)</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="58">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="58">
+          
           
           <code class="ruby">  click_button(&quot;update_password&quot;)</code>
         </li>
@@ -14972,8 +10149,8 @@
           <code class="ruby">Then /I can see the tutor name &quot;(.*)&quot;/ do |name|</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="62">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="62">
+          
           
           <code class="ruby">  expect(page).to have_content(name)</code>
         </li>
@@ -14996,8 +10173,8 @@
           <code class="ruby">Then /I can see the composition score of &quot;(.*)&quot;/ do |score|</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="66">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="66">
+          
           
           <code class="ruby">  expect(page).to have_content(score)</code>
         </li>
@@ -15026,38 +10203,38 @@
           <code class="ruby"></code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="71">
-          <span class="hits">6</span>
+        <li class="missed" data-hits="0" data-linenumber="71">
+          
           
           <code class="ruby">  tutee = Tutee.find_by_first_name(first_name)</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="72">
-          <span class="hits">6</span>
+        <li class="missed" data-hits="0" data-linenumber="72">
+          
           
           <code class="ruby">  tutor = Tutor.find_by_first_name(tutorname)</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="73">
-          <span class="hits">6</span>
+        <li class="missed" data-hits="0" data-linenumber="73">
+          
           
           <code class="ruby">  request = Request.new()</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="74">
-          <span class="hits">6</span>
+        <li class="missed" data-hits="0" data-linenumber="74">
+          
           
           <code class="ruby">  request.tutee_id = tutee.id</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="75">
-          <span class="hits">6</span>
+        <li class="missed" data-hits="0" data-linenumber="75">
+          
           
           <code class="ruby">  course = Course.find_by_name(coursename)</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="76">
-          <span class="hits">6</span>
+        <li class="missed" data-hits="0" data-linenumber="76">
+          
           
           <code class="ruby">  course.name = coursename</code>
         </li>
@@ -15068,8 +10245,8 @@
           <code class="ruby"></code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="78">
-          <span class="hits">6</span>
+        <li class="missed" data-hits="0" data-linenumber="78">
+          
           
           <code class="ruby">  request.course_id = course.id</code>
         </li>
@@ -15080,44 +10257,44 @@
           <code class="ruby"></code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="80">
-          <span class="hits">6</span>
+        <li class="missed" data-hits="0" data-linenumber="80">
+          
           
           <code class="ruby">  request.save!</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="81">
-          <span class="hits">6</span>
+        <li class="missed" data-hits="0" data-linenumber="81">
+          
           
           <code class="ruby">  eval = Evaluation.new()</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="82">
-          <span class="hits">6</span>
+        <li class="missed" data-hits="0" data-linenumber="82">
+          
           
           <code class="ruby">  eval.status = stat</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="83">
-          <span class="hits">6</span>
+        <li class="missed" data-hits="0" data-linenumber="83">
+          
           
           <code class="ruby">  eval.knowledgeable = kl</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="84">
-          <span class="hits">6</span>
+        <li class="missed" data-hits="0" data-linenumber="84">
+          
           
           <code class="ruby">  eval.helpful = hp</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="85">
-          <span class="hits">6</span>
+        <li class="missed" data-hits="0" data-linenumber="85">
+          
           
           <code class="ruby">  eval.clarity = cl</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="86">
-          <span class="hits">6</span>
+        <li class="missed" data-hits="0" data-linenumber="86">
+          
           
           <code class="ruby">  eval.save!</code>
         </li>
@@ -15128,14 +10305,14 @@
           <code class="ruby"></code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="88">
-          <span class="hits">6</span>
+        <li class="missed" data-hits="0" data-linenumber="88">
+          
           
           <code class="ruby">  meeting = Meeting.new()</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="89">
-          <span class="hits">6</span>
+        <li class="missed" data-hits="0" data-linenumber="89">
+          
           
           <code class="ruby">  meeting.request_id = request.id</code>
         </li>
@@ -15146,8 +10323,8 @@
           <code class="ruby"></code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="91">
-          <span class="hits">6</span>
+        <li class="missed" data-hits="0" data-linenumber="91">
+          
           
           <code class="ruby">  meeting.tutor =tutor</code>
         </li>
@@ -15158,8 +10335,8 @@
           <code class="ruby"></code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="93">
-          <span class="hits">6</span>
+        <li class="missed" data-hits="0" data-linenumber="93">
+          
           
           <code class="ruby">  meeting.evaluation_id = eval.id</code>
         </li>
@@ -15170,8 +10347,8 @@
           <code class="ruby"></code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="95">
-          <span class="hits">6</span>
+        <li class="missed" data-hits="0" data-linenumber="95">
+          
           
           <code class="ruby">  meeting.save!</code>
         </li>
@@ -15194,14 +10371,14 @@
           <code class="ruby">Then /I can see sids &quot;(.*)&quot;/ do |sid_list|</code>
         </li>
       
-        <li class="covered" data-hits="12" data-linenumber="99">
-          <span class="hits">12</span>
+        <li class="missed" data-hits="0" data-linenumber="99">
+          
           
           <code class="ruby">  sid_list.to_s.split(&quot;, &quot;).each do |sid|</code>
         </li>
       
-        <li class="covered" data-hits="40" data-linenumber="100">
-          <span class="hits">40</span>
+        <li class="missed" data-hits="0" data-linenumber="100">
+          
           
           <code class="ruby">    expect(page).to have_content(sid)</code>
         </li>
@@ -15224,8 +10401,8 @@
           <code class="ruby">Then /I can not see sid &quot;(.*)&quot;/ do |sid|</code>
         </li>
       
-        <li class="covered" data-hits="12" data-linenumber="104">
-          <span class="hits">12</span>
+        <li class="missed" data-hits="0" data-linenumber="104">
+          
           
           <code class="ruby">  expect(page).to have_no_content(sid)</code>
         </li>
@@ -15248,20 +10425,20 @@
           <code class="ruby">When /I make an update for CS61A scholars to &quot;(.*)&quot;/ do |sid_list|</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="108">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="108">
+          
           
           <code class="ruby">  obj = page.find(:xpath, &#39;//*[@id=&quot;update_student_priorities_CS61A&quot;]&#39;,visible: false)</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="109">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="109">
+          
           
           <code class="ruby">  obj.set(sid_list.to_s.gsub(/, /, &quot;\r\n&quot;))</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="110">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="110">
+          
           
           <code class="ruby">  page.find(:xpath, &#39;//*[@id=&quot;update_cs61a_scholars_button&quot;]&#39;,visible: false).click</code>
         </li>
@@ -15284,20 +10461,20 @@
           <code class="ruby">When /I make an update for CS61B scholars to &quot;(.*)&quot;/ do |sid_list|</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="114">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="114">
+          
           
           <code class="ruby">  obj = page.find(:xpath, &#39;//*[@id=&quot;update_student_priorities_CS61B&quot;]&#39;,visible: false)</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="115">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="115">
+          
           
           <code class="ruby">  obj.set(sid_list.to_s.gsub(/, /, &quot;\r\n&quot;))</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="116">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="116">
+          
           
           <code class="ruby">  page.find(:xpath, &#39;//*[@id=&quot;update_cs61b_scholars_button&quot;]&#39;,visible: false).click</code>
         </li>
@@ -15320,20 +10497,20 @@
           <code class="ruby">When /I make an update for CS61C scholars to &quot;(.*)&quot;/ do |sid_list|</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="120">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="120">
+          
           
           <code class="ruby">  obj = page.find(:xpath, &#39;//*[@id=&quot;update_student_priorities_CS61C&quot;]&#39;,visible: false)</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="121">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="121">
+          
           
           <code class="ruby">  obj.set(sid_list.to_s.gsub(/, /, &quot;\r\n&quot;))</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="122">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="122">
+          
           
           <code class="ruby">  page.find(:xpath, &#39;//*[@id=&quot;update_cs61c_scholars_button&quot;]&#39;,visible: false).click</code>
         </li>
@@ -15356,20 +10533,20 @@
           <code class="ruby">When /I make an update for CS70 scholars to &quot;(.*)&quot;/ do |sid_list|</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="126">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="126">
+          
           
           <code class="ruby">  obj = page.find(:xpath, &#39;//*[@id=&quot;update_student_priorities_CS70&quot;]&#39;,visible: false)</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="127">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="127">
+          
           
           <code class="ruby">  obj.set(sid_list.to_s.gsub(/, /, &quot;\r\n&quot;))</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="128">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="128">
+          
           
           <code class="ruby">  page.find(:xpath, &#39;//*[@id=&quot;update_cs70_scholars_button&quot;]&#39;,visible: false).click</code>
         </li>
@@ -15391,7 +10568,7 @@
 </div>
 
       
-        <div class="source_table" id="845ee0c5bc42d1c3e52087f03107c0a4c3a2c86b">
+        <div class="source_table" id="498ff13ddd1103f178b7f7a4a554f792f71e3371">
   <div class="header">
     <h3>features/step_denifition/course_steps.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -15411,14 +10588,14 @@
           <code class="ruby">Given /the following courses exist/ do |courses_table|</code>
         </li>
       
-        <li class="covered" data-hits="21" data-linenumber="2">
-          <span class="hits">21</span>
+        <li class="covered" data-hits="5" data-linenumber="2">
+          <span class="hits">5</span>
           
           <code class="ruby">  courses_table.hashes.each do |course|</code>
         </li>
       
-        <li class="covered" data-hits="42" data-linenumber="3">
-          <span class="hits">42</span>
+        <li class="covered" data-hits="5" data-linenumber="3">
+          <span class="hits">5</span>
           
           <code class="ruby">    Course.create course</code>
         </li>
@@ -15440,14 +10617,14 @@
 </div>
 
       
-        <div class="source_table" id="6861c03d7aee2fa2138b07aebb1fd8f8c6dd1d00">
+        <div class="source_table" id="382582750f441300058ca7c0e9f1ca63eae02c46">
   <div class="header">
     <h3>features/step_denifition/evaluation_steps.rb</h3>
-    <h4><span class="green">93.18 %</span> covered</h4>
+    <h4><span class="red">60.23 %</span> covered</h4>
     <div>
       <b>88</b> relevant lines. 
-      <span class="green"><b>82</b> lines covered</span> and
-      <span class="red"><b>6</b> lines missed.</span>
+      <span class="green"><b>53</b> lines covered</span> and
+      <span class="red"><b>35</b> lines missed.</span>
     </div>
   </div>
   
@@ -15460,14 +10637,14 @@
           <code class="ruby">Given /the following meetings exist/ do |meetings_table|</code>
         </li>
       
-        <li class="covered" data-hits="1" data-linenumber="2">
-          <span class="hits">1</span>
+        <li class="missed" data-hits="0" data-linenumber="2">
+          
           
           <code class="ruby">  meetings_table.hashes.each do |meet|</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="3">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="3">
+          
           
           <code class="ruby">    Meeting.create meet</code>
         </li>
@@ -15496,14 +10673,14 @@
           <code class="ruby">Given /the following evaluations exist/ do |evaluations_table|</code>
         </li>
       
-        <li class="covered" data-hits="3" data-linenumber="8">
-          <span class="hits">3</span>
+        <li class="missed" data-hits="0" data-linenumber="8">
+          
           
           <code class="ruby">  evaluations_table.hashes.each do |eval|</code>
         </li>
       
-        <li class="covered" data-hits="4" data-linenumber="9">
-          <span class="hits">4</span>
+        <li class="missed" data-hits="0" data-linenumber="9">
+          
           
           <code class="ruby">    Evaluation.create eval</code>
         </li>
@@ -15610,104 +10787,104 @@
           <code class="ruby">Given /&quot;(.*)&quot; had a meeting with tutor &quot;(.*)&quot; with meeting id &quot;(.*)&quot; request having tutuee id &quot;(.*)&quot; course name &quot;(.*)&quot; and evaluation status &quot;(.*)&quot; feedback &quot;(.*)&quot;/ do |first_name, tutorname, meetid, tuteeid, coursename,stat,feed|</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="27">
-          <span class="hits">6</span>
+        <li class="covered" data-hits="5" data-linenumber="27">
+          <span class="hits">5</span>
           
           <code class="ruby">  tutee = Tutee.find_by_first_name(first_name)</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="28">
-          <span class="hits">6</span>
+        <li class="covered" data-hits="5" data-linenumber="28">
+          <span class="hits">5</span>
           
           <code class="ruby">  tutor = Tutor.find_by_first_name(tutorname)</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="29">
-          <span class="hits">6</span>
+        <li class="covered" data-hits="5" data-linenumber="29">
+          <span class="hits">5</span>
           
           <code class="ruby">  request = Request.new()</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="30">
-          <span class="hits">6</span>
+        <li class="covered" data-hits="5" data-linenumber="30">
+          <span class="hits">5</span>
           
           <code class="ruby">  request.tutee_id = tutee.id</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="31">
-          <span class="hits">6</span>
+        <li class="covered" data-hits="5" data-linenumber="31">
+          <span class="hits">5</span>
           
           <code class="ruby">  course = Course.find_by_name(coursename)</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="32">
-          <span class="hits">6</span>
+        <li class="covered" data-hits="5" data-linenumber="32">
+          <span class="hits">5</span>
           
           <code class="ruby">  course.name = coursename</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="33">
-          <span class="hits">6</span>
+        <li class="covered" data-hits="5" data-linenumber="33">
+          <span class="hits">5</span>
           
           <code class="ruby">  request.course_id = course.id</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="34">
-          <span class="hits">6</span>
+        <li class="covered" data-hits="5" data-linenumber="34">
+          <span class="hits">5</span>
           
           <code class="ruby">  request.save!</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="35">
-          <span class="hits">6</span>
+        <li class="covered" data-hits="5" data-linenumber="35">
+          <span class="hits">5</span>
           
           <code class="ruby">  eval = Evaluation.new()</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="36">
-          <span class="hits">6</span>
+        <li class="covered" data-hits="5" data-linenumber="36">
+          <span class="hits">5</span>
           
           <code class="ruby">  eval.status = stat</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="37">
-          <span class="hits">6</span>
+        <li class="covered" data-hits="5" data-linenumber="37">
+          <span class="hits">5</span>
           
           <code class="ruby">  eval.feedback = feed</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="38">
-          <span class="hits">6</span>
+        <li class="covered" data-hits="5" data-linenumber="38">
+          <span class="hits">5</span>
           
           <code class="ruby">  eval.save!</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="39">
-          <span class="hits">6</span>
+        <li class="covered" data-hits="5" data-linenumber="39">
+          <span class="hits">5</span>
           
           <code class="ruby">  meeting = Meeting.new()</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="40">
-          <span class="hits">6</span>
+        <li class="covered" data-hits="5" data-linenumber="40">
+          <span class="hits">5</span>
           
           <code class="ruby">  meeting.request_id = request.id</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="41">
-          <span class="hits">6</span>
+        <li class="covered" data-hits="5" data-linenumber="41">
+          <span class="hits">5</span>
           
           <code class="ruby">  meeting.tutor_id = tutor.id</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="42">
-          <span class="hits">6</span>
+        <li class="covered" data-hits="5" data-linenumber="42">
+          <span class="hits">5</span>
           
           <code class="ruby">  meeting.evaluation_id = eval.id</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="43">
-          <span class="hits">6</span>
+        <li class="covered" data-hits="5" data-linenumber="43">
+          <span class="hits">5</span>
           
           <code class="ruby">  meeting.save!</code>
         </li>
@@ -15736,116 +10913,116 @@
           <code class="ruby">Given /&quot;(.*)&quot; had a meeting with tutor &quot;(.*)&quot; with meeting id &quot;(.*)&quot; request having tutuee id &quot;(.*)&quot; course name &quot;(.*)&quot; and evaluation status &quot;(.*)&quot; times &quot;(.*)&quot; and locations &quot;(.*)&quot;/ do |first_name, tutorname, meetid, tuteeid, coursename,stat, times, locations|</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="48">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="48">
+          
           
           <code class="ruby">  tutee = Tutee.find_by_first_name(first_name)</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="49">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="49">
+          
           
           <code class="ruby">  tutor = Tutor.find_by_first_name(tutorname)</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="50">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="50">
+          
           
           <code class="ruby">  request = Request.new()</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="51">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="51">
+          
           
           <code class="ruby">  puts &quot;Tutee id&quot;</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="52">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="52">
+          
           
           <code class="ruby">  puts tutee.first_name</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="53">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="53">
+          
           
           <code class="ruby">  request.tutee_id = tutee.id</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="54">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="54">
+          
           
           <code class="ruby">  course = Course.find_by_name(coursename)</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="55">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="55">
+          
           
           <code class="ruby">  course.name = coursename</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="56">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="56">
+          
           
           <code class="ruby">  puts &quot;course id&quot;</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="57">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="57">
+          
           
           <code class="ruby">  request.course_id = course.id</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="58">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="58">
+          
           
           <code class="ruby">  puts course.id</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="59">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="59">
+          
           
           <code class="ruby">  request.save!</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="60">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="60">
+          
           
           <code class="ruby">  eval = Evaluation.new()</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="61">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="61">
+          
           
           <code class="ruby">  eval.status = stat</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="62">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="62">
+          
           
           <code class="ruby">  eval.save!</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="63">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="63">
+          
           
           <code class="ruby">  meeting = Meeting.new()</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="64">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="64">
+          
           
           <code class="ruby">  meeting.request_id = request.id</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="65">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="65">
+          
           
           <code class="ruby">  meeting.times = times.split(&quot;,&quot;)</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="66">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="66">
+          
           
           <code class="ruby">  meeting.locations = locations.split(&quot;,&quot;)</code>
         </li>
@@ -15856,38 +11033,38 @@
           <code class="ruby"></code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="68">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="68">
+          
           
           <code class="ruby">  puts request.id </code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="69">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="69">
+          
           
           <code class="ruby">  meeting.tutor_id = tutor.id</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="70">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="70">
+          
           
           <code class="ruby">  puts tutor.id</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="71">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="71">
+          
           
           <code class="ruby">  meeting.evaluation_id = eval.id</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="72">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="72">
+          
           
           <code class="ruby">  puts eval.id</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="73">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="73">
+          
           
           <code class="ruby">  meeting.save!</code>
         </li>
@@ -16413,14 +11590,14 @@
 </div>
 
       
-        <div class="source_table" id="50d7512d3a24f5d34532c5d80166fee4f6071a62">
+        <div class="source_table" id="0b70e7c59ed82f487b6a8d6859fd3b630aa0df6c">
   <div class="header">
     <h3>features/step_denifition/history_steps.rb</h3>
-    <h4><span class="green">100.0 %</span> covered</h4>
+    <h4><span class="red">62.5 %</span> covered</h4>
     <div>
       <b>8</b> relevant lines. 
-      <span class="green"><b>8</b> lines covered</span> and
-      <span class="red"><b>0</b> lines missed.</span>
+      <span class="green"><b>5</b> lines covered</span> and
+      <span class="red"><b>3</b> lines missed.</span>
     </div>
   </div>
   
@@ -16433,8 +11610,8 @@
           <code class="ruby">When /I click on &quot;(.*)&quot; link/ do |link|</code>
         </li>
       
-        <li class="covered" data-hits="12" data-linenumber="2">
-          <span class="hits">12</span>
+        <li class="covered" data-hits="7" data-linenumber="2">
+          <span class="hits">7</span>
           
           <code class="ruby">  click_link(link)</code>
         </li>
@@ -16463,8 +11640,8 @@
           <code class="ruby">Then /can see my history request with first_name &quot;(.*)&quot;/ do |name|</code>
         </li>
       
-        <li class="covered" data-hits="1" data-linenumber="7">
-          <span class="hits">1</span>
+        <li class="missed" data-hits="0" data-linenumber="7">
+          
           
           <code class="ruby">  page.should have_content(name)</code>
         </li>
@@ -16487,8 +11664,8 @@
           <code class="ruby">Then /can see my history request with course_name &quot;(.*)&quot;/ do |name|</code>
         </li>
       
-        <li class="covered" data-hits="1" data-linenumber="11">
-          <span class="hits">1</span>
+        <li class="missed" data-hits="0" data-linenumber="11">
+          
           
           <code class="ruby">  page.should have_content(name)</code>
         </li>
@@ -16511,8 +11688,8 @@
           <code class="ruby">Then /can see my history request with status evaluation &quot;(.*)&quot;/ do |status|</code>
         </li>
       
-        <li class="covered" data-hits="1" data-linenumber="15">
-          <span class="hits">1</span>
+        <li class="missed" data-hits="0" data-linenumber="15">
+          
           
           <code class="ruby">  page.should have_content(status)</code>
         </li>
@@ -16528,14 +11705,14 @@
 </div>
 
       
-        <div class="source_table" id="b3ef0b9a5c6e0893341ed6c461e27acba107c545">
+        <div class="source_table" id="4a02fb61d3c756f29c1ad2bbce5c8e7e6650d4fe">
   <div class="header">
     <h3>features/step_denifition/request_steps.rb</h3>
-    <h4><span class="green">100.0 %</span> covered</h4>
+    <h4><span class="red">50.0 %</span> covered</h4>
     <div>
       <b>20</b> relevant lines. 
-      <span class="green"><b>20</b> lines covered</span> and
-      <span class="red"><b>0</b> lines missed.</span>
+      <span class="green"><b>10</b> lines covered</span> and
+      <span class="red"><b>10</b> lines missed.</span>
     </div>
   </div>
   
@@ -16548,14 +11725,14 @@
           <code class="ruby">Given /the following requests exist/ do |requests_table|</code>
         </li>
       
-        <li class="covered" data-hits="10" data-linenumber="2">
-          <span class="hits">10</span>
+        <li class="covered" data-hits="5" data-linenumber="2">
+          <span class="hits">5</span>
           
           <code class="ruby">  requests_table.hashes.each do |request|</code>
         </li>
       
-        <li class="covered" data-hits="12" data-linenumber="3">
-          <span class="hits">12</span>
+        <li class="covered" data-hits="5" data-linenumber="3">
+          <span class="hits">5</span>
           
           <code class="ruby">    Request.create request</code>
         </li>
@@ -16584,20 +11761,20 @@
           <code class="ruby">When /I make a request for &quot;(.*)&quot; with topic &quot;(.*)&quot;/ do |course, topic|</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="8">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="8">
+          
           
           <code class="ruby">  click_link(&quot;Request&quot;)</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="9">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="9">
+          
           
           <code class="ruby">  steps %Q{When I choose &quot;#{course}&quot; from course list}</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="10">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="10">
+          
           
           <code class="ruby">  steps %Q{When I input subject &quot;#{topic}&quot; I want to cover}</code>
         </li>
@@ -16620,8 +11797,8 @@
           <code class="ruby">When /I choose &quot;(.*)&quot; from course list/ do |course|</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="14">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="14">
+          
           
           <code class="ruby">  steps %Q{When I select &quot;#{course}&quot; from &quot;request_course_id&quot;}</code>
         </li>
@@ -16644,8 +11821,8 @@
           <code class="ruby">When /I input subject &quot;(.*)&quot; I want to cover/ do |subject|</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="18">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="18">
+          
           
           <code class="ruby">  page.find(:xpath, &#39;//*[@id=&quot;request_subject&quot;]&#39;).set(subject)</code>
         </li>
@@ -16668,8 +11845,8 @@
           <code class="ruby">When /I select Request Tuttor button/ do</code>
         </li>
       
-        <li class="covered" data-hits="4" data-linenumber="22">
-          <span class="hits">4</span>
+        <li class="missed" data-hits="0" data-linenumber="22">
+          
           
           <code class="ruby">  click_button(&#39;request_tutor&#39;)</code>
         </li>
@@ -16692,8 +11869,8 @@
           <code class="ruby">Then /I can see &quot;(.*)&quot; message pop up/ do |text|</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="26">
-          <span class="hits">6</span>
+        <li class="missed" data-hits="0" data-linenumber="26">
+          
           
           <code class="ruby">  expect(page).to have_content(text)</code>
         </li>
@@ -16716,14 +11893,14 @@
           <code class="ruby">When /I make a request for &quot;(.*)&quot; without inputting topic/ do |course|</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="30">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="30">
+          
           
           <code class="ruby">  click_link(&quot;Request&quot;)</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="31">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="31">
+          
           
           <code class="ruby">  steps %Q{I choose #{course} from course list}</code>
         </li>
@@ -16746,8 +11923,8 @@
           <code class="ruby">When /I choose &quot;(.*)&quot; from meeting time list/ do |time|</code>
         </li>
       
-        <li class="covered" data-hits="7" data-linenumber="35">
-          <span class="hits">7</span>
+        <li class="missed" data-hits="0" data-linenumber="35">
+          
           
           <code class="ruby">  page.find(:xpath, &#39;//*[@id=&quot;request_meeting_length&quot;]&#39;,visible: false).all(:css, &#39;option&#39;).find { |o| o.text == time }.select_option</code>
         </li>
@@ -16763,7 +11940,7 @@
 </div>
 
       
-        <div class="source_table" id="faf42076eee8925d4e0b1ece682ad11f6e269972">
+        <div class="source_table" id="bd33698cd2881071514a41b22b2027b33b57991d">
   <div class="header">
     <h3>features/step_denifition/support_steps.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -16806,14 +11983,14 @@
 </div>
 
       
-        <div class="source_table" id="783a7f10cbebe5bb3ffc8cda0874eb1c9150e7c4">
+        <div class="source_table" id="c17eb2a1a26e070f9f395956512d418b79b907a7">
   <div class="header">
     <h3>features/step_denifition/tutee_steps.rb</h3>
-    <h4><span class="green">94.29 %</span> covered</h4>
+    <h4><span class="red">77.14 %</span> covered</h4>
     <div>
       <b>35</b> relevant lines. 
-      <span class="green"><b>33</b> lines covered</span> and
-      <span class="red"><b>2</b> lines missed.</span>
+      <span class="green"><b>27</b> lines covered</span> and
+      <span class="red"><b>8</b> lines missed.</span>
     </div>
   </div>
   
@@ -16898,14 +12075,14 @@
           <code class="ruby">Given /the following tutees exist/ do |tutees_table|</code>
         </li>
       
-        <li class="covered" data-hits="42" data-linenumber="14">
-          <span class="hits">42</span>
+        <li class="covered" data-hits="5" data-linenumber="14">
+          <span class="hits">5</span>
           
           <code class="ruby">  tutees_table.hashes.each do |tutee|</code>
         </li>
       
-        <li class="covered" data-hits="91" data-linenumber="15">
-          <span class="hits">91</span>
+        <li class="covered" data-hits="10" data-linenumber="15">
+          <span class="hits">10</span>
           
           <code class="ruby">    Tutee.create tutee</code>
         </li>
@@ -16934,8 +12111,8 @@
           <code class="ruby">Given /^(?:|I )am on (.+)$/ do |page_name|</code>
         </li>
       
-        <li class="covered" data-hits="115" data-linenumber="20">
-          <span class="hits">115</span>
+        <li class="covered" data-hits="9" data-linenumber="20">
+          <span class="hits">9</span>
           
           <code class="ruby">  visit path_to(page_name)</code>
         </li>
@@ -16958,8 +12135,8 @@
           <code class="ruby">And /^(?:|I )fill in &quot;([^&quot;]*)&quot; with &quot;([^&quot;]*)&quot;$/ do |field, value|</code>
         </li>
       
-        <li class="covered" data-hits="201" data-linenumber="24">
-          <span class="hits">201</span>
+        <li class="covered" data-hits="23" data-linenumber="24">
+          <span class="hits">23</span>
           
           <code class="ruby">  fill_in(field, :with =&gt; value)</code>
         </li>
@@ -16982,8 +12159,8 @@
           <code class="ruby">And /^(?:|I )change &quot;([^&quot;]*)&quot; to &quot;([^&quot;]*)&quot;$/ do |field, value|</code>
         </li>
       
-        <li class="covered" data-hits="12" data-linenumber="28">
-          <span class="hits">12</span>
+        <li class="missed" data-hits="0" data-linenumber="28">
+          
           
           <code class="ruby">  fill_in(field, :with =&gt; value)</code>
         </li>
@@ -17006,8 +12183,8 @@
           <code class="ruby">Then(/^I should see &quot;(.*?)&quot;$/) do |arg1|</code>
         </li>
       
-        <li class="covered" data-hits="49" data-linenumber="32">
-          <span class="hits">49</span>
+        <li class="covered" data-hits="8" data-linenumber="32">
+          <span class="hits">8</span>
           
           <code class="ruby">  page.should have_content(&quot;#{arg1}&quot;)</code>
         </li>
@@ -17030,8 +12207,8 @@
           <code class="ruby">When /^(?:|I )press &quot;([^&quot;]*)&quot;$/ do |button|</code>
         </li>
       
-        <li class="covered" data-hits="98" data-linenumber="36">
-          <span class="hits">98</span>
+        <li class="covered" data-hits="8" data-linenumber="36">
+          <span class="hits">8</span>
           
           <code class="ruby">  click_button(button)</code>
         </li>
@@ -17054,8 +12231,8 @@
           <code class="ruby">When /^(?:|I )press link &quot;([^&quot;]*)&quot;$/ do |link|</code>
         </li>
       
-        <li class="covered" data-hits="40" data-linenumber="40">
-          <span class="hits">40</span>
+        <li class="missed" data-hits="0" data-linenumber="40">
+          
           
           <code class="ruby">  click_link(link)</code>
         </li>
@@ -17078,20 +12255,20 @@
           <code class="ruby">And /^(?:|I )should be on (.+)$/ do |page_name|</code>
         </li>
       
-        <li class="covered" data-hits="87" data-linenumber="44">
-          <span class="hits">87</span>
+        <li class="missed" data-hits="0" data-linenumber="44">
+          
           
           <code class="ruby">  current_path = URI.parse(current_url).path</code>
         </li>
       
-        <li class="covered" data-hits="87" data-linenumber="45">
-          <span class="hits">87</span>
+        <li class="missed" data-hits="0" data-linenumber="45">
+          
           
           <code class="ruby">  if current_path.respond_to? :should</code>
         </li>
       
-        <li class="covered" data-hits="87" data-linenumber="46">
-          <span class="hits">87</span>
+        <li class="missed" data-hits="0" data-linenumber="46">
+          
           
           <code class="ruby">    current_path.should == path_to(page_name)</code>
         </li>
@@ -17132,8 +12309,8 @@
           <code class="ruby">And /^(?:|I )select &quot;([^&quot;]*)&quot; from &quot;([^&quot;]*)&quot;$/ do |value, field|</code>
         </li>
       
-        <li class="covered" data-hits="3" data-linenumber="53">
-          <span class="hits">3</span>
+        <li class="missed" data-hits="0" data-linenumber="53">
+          
           
           <code class="ruby">  select(value, :from =&gt; field)</code>
         </li>
@@ -17162,26 +12339,26 @@
           <code class="ruby">Given /I login as &quot;(.*)&quot;/ do |name|</code>
         </li>
       
-        <li class="covered" data-hits="12" data-linenumber="58">
-          <span class="hits">12</span>
+        <li class="covered" data-hits="4" data-linenumber="58">
+          <span class="hits">4</span>
           
           <code class="ruby">  step %{I am on the login page}</code>
         </li>
       
-        <li class="covered" data-hits="12" data-linenumber="59">
-          <span class="hits">12</span>
+        <li class="covered" data-hits="4" data-linenumber="59">
+          <span class="hits">4</span>
           
           <code class="ruby">  step %{I fill in &quot;username&quot; with &quot;#{Tutee.find_by_first_name(name).email}&quot;}</code>
         </li>
       
-        <li class="covered" data-hits="12" data-linenumber="60">
-          <span class="hits">12</span>
+        <li class="covered" data-hits="4" data-linenumber="60">
+          <span class="hits">4</span>
           
           <code class="ruby">  step %{I fill in &quot;password&quot; with &quot;topsecret&quot;}</code>
         </li>
       
-        <li class="covered" data-hits="12" data-linenumber="61">
-          <span class="hits">12</span>
+        <li class="covered" data-hits="4" data-linenumber="61">
+          <span class="hits">4</span>
           
           <code class="ruby">  step %{press &quot;Log in&quot;}</code>
         </li>
@@ -17269,7 +12446,7 @@
 </div>
 
       
-        <div class="source_table" id="3301fcdf4b19dc2f2bba4994feb707cea6a4149e">
+        <div class="source_table" id="81af62f4b2c71ac3de792322efa2fc0f9c357ab2">
   <div class="header">
     <h3>features/step_denifition/web_steps.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -17306,14 +12483,14 @@
 </div>
 
       
-        <div class="source_table" id="bd764ab7f1597e138b783e82d36acd477b97beef">
+        <div class="source_table" id="f7050d982af38f0ab040c8011cb30da4471a0981">
   <div class="header">
     <h3>features/support/paths.rb</h3>
-    <h4><span class="green">90.91 %</span> covered</h4>
+    <h4><span class="red">45.45 %</span> covered</h4>
     <div>
       <b>33</b> relevant lines. 
-      <span class="green"><b>30</b> lines covered</span> and
-      <span class="red"><b>3</b> lines missed.</span>
+      <span class="green"><b>15</b> lines covered</span> and
+      <span class="red"><b>18</b> lines missed.</span>
     </div>
   </div>
   
@@ -17374,8 +12551,8 @@
           <code class="ruby">  def path_to(page_name)</code>
         </li>
       
-        <li class="covered" data-hits="209" data-linenumber="10">
-          <span class="hits">209</span>
+        <li class="covered" data-hits="9" data-linenumber="10">
+          <span class="hits">9</span>
           
           <code class="ruby">    case page_name</code>
         </li>
@@ -17392,8 +12569,8 @@
           <code class="ruby">    when /the login page/</code>
         </li>
       
-        <li class="covered" data-hits="47" data-linenumber="13">
-          <span class="hits">47</span>
+        <li class="covered" data-hits="4" data-linenumber="13">
+          <span class="hits">4</span>
           
           <code class="ruby">      new_tutee_session_path</code>
         </li>
@@ -17410,8 +12587,8 @@
           <code class="ruby">    when /the user page for &quot;(.*)&quot;$/</code>
         </li>
       
-        <li class="covered" data-hits="18" data-linenumber="16">
-          <span class="hits">18</span>
+        <li class="missed" data-hits="0" data-linenumber="16">
+          
           
           <code class="ruby">      tutee_path(Tutee.find_by_email($1)[:id])</code>
         </li>
@@ -17428,8 +12605,8 @@
           <code class="ruby">    when /the update page for &quot;(.*)&quot;$/</code>
         </li>
       
-        <li class="covered" data-hits="24" data-linenumber="19">
-          <span class="hits">24</span>
+        <li class="missed" data-hits="0" data-linenumber="19">
+          
           
           <code class="ruby">      edit_tutee_registration_path(Tutee.find_by_email($1)[:id])</code>
         </li>
@@ -17524,8 +12701,8 @@
           <code class="ruby">    when /the create account page/</code>
         </li>
       
-        <li class="covered" data-hits="22" data-linenumber="35">
-          <span class="hits">22</span>
+        <li class="missed" data-hits="0" data-linenumber="35">
+          
           
           <code class="ruby">      new_tutee_registration_path</code>
         </li>
@@ -17542,8 +12719,8 @@
           <code class="ruby">    when /&quot;(.*)&#39;s&quot; tutee page$/</code>
         </li>
       
-        <li class="covered" data-hits="14" data-linenumber="38">
-          <span class="hits">14</span>
+        <li class="covered" data-hits="4" data-linenumber="38">
+          <span class="hits">4</span>
           
           <code class="ruby">      tutee_path(Tutee.find_by_first_name($1))</code>
         </li>
@@ -17560,8 +12737,8 @@
           <code class="ruby">    when /the update semester page/</code>
         </li>
       
-        <li class="covered" data-hits="3" data-linenumber="41">
-          <span class="hits">3</span>
+        <li class="missed" data-hits="0" data-linenumber="41">
+          
           
           <code class="ruby">      admin_update_semester_path</code>
         </li>
@@ -17578,8 +12755,8 @@
           <code class="ruby">    when /the update courses page/</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="44">
-          <span class="hits">6</span>
+        <li class="missed" data-hits="0" data-linenumber="44">
+          
           
           <code class="ruby">      admin_update_courses_path</code>
         </li>
@@ -17596,8 +12773,8 @@
           <code class="ruby">    when /the update admin password/</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="47">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="47">
+          
           
           <code class="ruby">      admin_update_password_path</code>
         </li>
@@ -17608,8 +12785,8 @@
           <code class="ruby">    when /the update priorities page/</code>
         </li>
       
-        <li class="covered" data-hits="8" data-linenumber="49">
-          <span class="hits">8</span>
+        <li class="missed" data-hits="0" data-linenumber="49">
+          
           
           <code class="ruby">      admin_update_student_priorities_path</code>
         </li>
@@ -17626,8 +12803,8 @@
           <code class="ruby">    when /the rating tutors page/</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="52">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="52">
+          
           
           <code class="ruby">      admin_rating_tutors_path</code>
         </li>
@@ -17644,8 +12821,8 @@
           <code class="ruby">    when /^the home\s?page$/</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="55">
-          <span class="hits">6</span>
+        <li class="missed" data-hits="0" data-linenumber="55">
+          
           
           <code class="ruby">      &#39;/&#39;</code>
         </li>
@@ -17662,8 +12839,8 @@
           <code class="ruby">    when /the admin landing page/</code>
         </li>
       
-        <li class="covered" data-hits="28" data-linenumber="58">
-          <span class="hits">28</span>
+        <li class="missed" data-hits="0" data-linenumber="58">
+          
           
           <code class="ruby">      admin_landing_path</code>
         </li>
@@ -17680,8 +12857,8 @@
           <code class="ruby">    when /the admin home page/</code>
         </li>
       
-        <li class="covered" data-hits="20" data-linenumber="61">
-          <span class="hits">20</span>
+        <li class="missed" data-hits="0" data-linenumber="61">
+          
           
           <code class="ruby">      admin_home_path</code>
         </li>
@@ -17716,8 +12893,8 @@
           <code class="ruby">    when /the welcome page/</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="67">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="67">
+          
           
           <code class="ruby">      homepage_path</code>
         </li>
@@ -17734,8 +12911,8 @@
           <code class="ruby">    when /the tutor update page for &quot;(.*)&quot;$/</code>
         </li>
       
-        <li class="covered" data-hits="3" data-linenumber="70">
-          <span class="hits">3</span>
+        <li class="missed" data-hits="0" data-linenumber="70">
+          
           
           <code class="ruby">      edit_tutor_path(Tutor.find_by_email($1)[:id])</code>
         </li>
@@ -17752,8 +12929,8 @@
           <code class="ruby">    when /the tutor page for &quot;(.*)&quot;$/</code>
         </li>
       
-        <li class="covered" data-hits="2" data-linenumber="73">
-          <span class="hits">2</span>
+        <li class="missed" data-hits="0" data-linenumber="73">
+          
           
           <code class="ruby">      tutor_path(Tutor.find_by_email($1)[:id])</code>
         </li>
@@ -17770,8 +12947,8 @@
           <code class="ruby">    when /find students page for &quot;(.*)&quot;$/</code>
         </li>
       
-        <li class="covered" data-hits="1" data-linenumber="76">
-          <span class="hits">1</span>
+        <li class="missed" data-hits="0" data-linenumber="76">
+          
           
           <code class="ruby">      tutor_find_students_path(Tutor.find_by_email($1)[:id])</code>
         </li>
@@ -17877,7 +13054,7 @@
 </div>
 
       
-        <div class="source_table" id="9676871e82061a50e2c6ce8bd6101458a40efb26">
+        <div class="source_table" id="e38f9e305fba98dadb325332863161f4e49306fb">
   <div class="header">
     <h3>features/support/selectors.rb</h3>
     <h4><span class="red">42.86 %</span> covered</h4>
@@ -18184,7 +13361,7 @@
 </div>
 
       
-        <div class="source_table" id="b02036a06eeeddc42c1494674a7cd7793d9d632b">
+        <div class="source_table" id="5577c3985fc6c72ffba376bad07e50ec79e833b1">
   <div class="header">
     <h3>spec/factories/admins.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -18245,7 +13422,7 @@
 </div>
 
       
-        <div class="source_table" id="9a66728ef334f4807d4be60d66abe34aed2f93a8">
+        <div class="source_table" id="008fe983d7a9a54d4574b2a0c1700ce915a070c0">
   <div class="header">
     <h3>spec/factories/core.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -18396,7 +13573,7 @@
 </div>
 
       
-        <div class="source_table" id="ed456db281e9883217ba6c8c5b36c73e67aca26b">
+        <div class="source_table" id="f74e125c408bdc284beebfd1324ea978665a9bae">
   <div class="header">
     <h3>spec/factories/courses.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -18457,7 +13634,7 @@
 </div>
 
       
-        <div class="source_table" id="ed1b6f5626733c923d46512f3a86d56daa3ca033">
+        <div class="source_table" id="52c160b9eeb7565b4dc4107517c545358ea652ca">
   <div class="header">
     <h3>spec/factories/evaluations.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -18512,7 +13689,7 @@
 </div>
 
       
-        <div class="source_table" id="7949e0b862cad1477cd473fa03d33ca4983881bc">
+        <div class="source_table" id="a3f953513375503138bfaac9ba873ee30ebcabb0">
   <div class="header">
     <h3>spec/factories/tutees.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>
@@ -19377,7 +14554,7 @@
 </div>
 
       
-        <div class="source_table" id="8ecab71feacd0062ef4582655419a66a8a9e9444">
+        <div class="source_table" id="0bb29179ea4cd08f9967d768379cd187501fb7b4">
   <div class="header">
     <h3>spec/factories/tutors.rb</h3>
     <h4><span class="green">100.0 %</span> covered</h4>

--- a/features/pending_evaluation.feature
+++ b/features/pending_evaluation.feature
@@ -17,7 +17,7 @@ Feature: submit evaluation
       |true  | false | false | false | false | false | false | false |40 |
       
     Given the following requests exist:
-      | tutee_id | course_id  | subject |
+      | tutee_id | course_id  | subject   |  
       | 1        | 1          | recursion  |
 
     Given the following tutors exist:


### PR DESCRIPTION
# [Pivotal Story Name]

## Purpose

The purpose of this Pull Request is to merge in fixes to the evaluation form filling process

## User Story

- As a Tutee
- When I try to fill in an Evaluation before the scheduled Meeting
- Then I should Land on a page that tells me I can only fill the Eval after the Meeting

## Changes

- views/evaluations/edit.html.haml
